### PR TITLE
Add building & uploading page

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -6,7 +6,7 @@ description: Learn about the Chromatic CLI options
 
 # Chromatic CLI
 
-The CLI builds then publishes Storybook. Run `chromatic` in your project directory.
+The [CLI](https://www.npmjs.com/package/chromatic) builds then publishes Storybook. Run `chromatic` in your project directory.
 
 ```bash
 ./node_modules/.bin/chromatic --project-token=<your-project-token>


### PR DESCRIPTION
Refs: https://github.com/chromaui/chromatic/issues/3696

I added the old post from Intercom with a few changes:

* Linking to packages
* Adding a note that `storybook-chromatic` is deprecated
* Syntax highlighting on a few commands/package names
* Small blurb under the top header so there is some content in between the header and first section heading

I decided to put this section under "Reference" in the sidebar, but not sure what sort of organization pattern we are going for there.

As always, open to suggestions!

View it in the deploy preview: https://deploy-preview-13--chromatic-docs.netlify.app/docs/building-and-uploading
