### PR TITLE
Preconnect to google CDN to speed up font loading

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,6 +32,8 @@
     sizes="16x16 32x32 64x64"
   />
 
+  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
+
   <link rel="stylesheet" href="prism.css" />
   <link rel="stylesheet" href="style.css" />
   <meta name="google-site-verification" content="FIXME" />


### PR DESCRIPTION
This preconnects to the google fonts domain so fonts load faster. Technique from [this article](https://medium.com/clio-calliope/making-google-fonts-faster-aadf3c02a36d).