### PR TITLE
Chore: Add missing step and fix broken link in document page

### DIFF
--- a/document.md
+++ b/document.md
@@ -34,7 +34,7 @@ Components and their stories are securely indexed each commit and branch. Use th
 
 Your Storybook is published on our secure CDN. Collaborators with [access rights](access) will also get access by logging in.
 
-Chromatic generates a [permalink](permalink) for the latest uploaded Storybook on a given branch. That makes it easy to share with your teammates or link to from docs. `https://<branch>--<appid>.chromatic.com`
+Chromatic generates a [permalink](permalinks) for the latest uploaded Storybook on a given branch. That makes it easy to share with your teammates or link to from docs. `https://<branch>--<appid>.chromatic.com`
 
 ![Direct Storybook](img/published-storybook.png)
 

--- a/github-actions.md
+++ b/github-actions.md
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
+      - uses: actions/checkout@v1
       - name: Install dependencies
         run: yarn
         # 👇 Adds Chromatic as a step in the workflow


### PR DESCRIPTION
With this pull request the missing step (checkout) is added in the github action documentation. Also a broken link in documentation page is fixed. Was pointing to a non existing page.

