### PR TITLE
Chore: (Docs) Adjust links of the LearnStorybook tutorials

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ Automate your component library with CI and version control. Chromatic includes 
 
 [Storybook](http://storybook.js.org) is an open source tool built for developing UI components in isolation and creating living, interactive component documentation. Storybook makes it trivial to reproduce hard to reach component states and ensuring those states are documented in code. When you adopt Storybook you also unlock automation for UI components and libraries via Chromatic.
 
-New to Storybook? Read our peer-reviewed guides for professional developers at [LearnStorybook.com](https://learnstorybook.com).
+New to Storybook? Read our peer-reviewed guides for professional developers at [storybook.js.org/tutorials](https://storybook.js.org/tutorials/).
 
 </details>
 

--- a/storybook.md
+++ b/storybook.md
@@ -8,7 +8,7 @@ description: Learn how to set up Storybook in your app to write snapshot specifi
 
 This tutorial is a quick overview that walks you through installing Storybook and integrating Chromatic. It's intended for folks who haven't yet used Storybook.
 
-If you're already using Storybook, then great!---skip to the [get started](/docs/) guide. If you'd prefer to learn Storybook in a free 11-chapter tutorial take a look at [Learn Storybook](https://www.learnstorybook.com/intro-to-storybook/).
+If you're already using Storybook, then great!---skip to the [get started](/docs/) guide. If you'd prefer to learn Storybook in a free 11-chapter tutorial take a look at the [Intro to Storybook tutorial](https://storybook.js.org/tutorials/intro-to-storybook/).
 
 #### How Chromatic works (in brief)
 
@@ -20,7 +20,7 @@ An image snapshot is taken of each story every commit. Chromatic compares these 
 
 ## What is Storybook?
 
-Storybook is the leading [component explorer](https://blog.hichroma.com/the-crucial-tool-for-modern-frontend-engineers-fb849b06187a) for React, Angular, and Vue. It provides a dedicated UI that helps you visualize, interact, and develop your component states (called "stories" in Storybook) even as you create them. When embedded in your development workflow, it's a timesaving tool for developing apps from the ground up in a [component-driven](https://www.componentdriven.org/) fashion. Storybook is an essential tool for developers building Component Libraries for Design System (read our [guide](https://www.learnstorybook.com/design-systems-for-developers/)).
+Storybook is the leading [component explorer](https://blog.hichroma.com/the-crucial-tool-for-modern-frontend-engineers-fb849b06187a) for React, Angular, and Vue. It provides a dedicated UI that helps you visualize, interact, and develop your component states (called "stories" in Storybook) even as you create them. When embedded in your development workflow, it's a timesaving tool for developing apps from the ground up in a [component-driven](https://www.componentdriven.org/) fashion. Storybook is an essential tool for developers building Component Libraries for Design System (read our [guide](https://storybook.js.org/tutorials/design-systems-for-developers/)).
 
 ![Storybook](img/storybook-relationship.jpg)
 
@@ -127,8 +127,8 @@ Grab the project token from [www.chromatic.com](https://www.chromatic.com) and v
 
 ## Resources
 
-- [Learn Storybook](https://learnstorybook.com) Step by step guides on learning Storybook and component development best practices
-- [Visual Testing Handbook](https://www.learnstorybook.com/visual-testing-handbook/) a free 31-page walkthrough for visual testing with Storybook
+- [Storybook tutorials](https://storybook.js.org/tutorials/) Step by step guides on learning Storybook and component development best practices
+- [Visual Testing Handbook](https://storybook.js.org/tutorials/visual-testing-handbook/) a free 31-page walkthrough for visual testing with Storybook
 - [Component Driven UIs](https://www.componentdriven.org/) How modularity is transforming design and frontend development
 - [How Storybook fits into your workflow](https://www.componentdriven.org/)
 - [Storybook docs](https://storybook.js.org/docs/react/get-started/introduction)

--- a/workflow.md
+++ b/workflow.md
@@ -44,9 +44,9 @@ You finished setting up Chromatic. We look forward to the incredible UIs you'll 
 
 #### Our most popular guides and articles
 
-- [Intro to Storybook](https://www.learnstorybook.com/intro-to-storybook/) is the essential guide to learning Storybook.
-- [Design Systems for Developers](https://www.learnstorybook.com/design-systems-for-developers/) shares how to build production infrastructure for design systems.
-- [Visual Testing Handbook](https://www.learnstorybook.com/visual-testing-handbook/) details how professional frontend teams visual test with Storybook.
+- [Intro to Storybook](https://storybook.js.org/tutorials/intro-to-storybook/) is the essential guide to learning Storybook.
+- [Design Systems for Developers](https://storybook.js.org/tutorials/design-systems-for-developers/) shares how to build production infrastructure for design systems.
+- [Visual Testing Handbook](https://storybook.js.org/tutorials/visual-testing-handbook/) details how professional frontend teams visual test with Storybook.
 - [Component-Driven Development](https://www.componentdriven.org/) is a "bottoms up" process for building modular UIs starting from components and ending with screens.
 - [UI Component Playbook](https://blog.hichroma.com/ui-component-playbook-fd3022d00590) is a 5-step overview of designing and engineering frontends with components
 


### PR DESCRIPTION
With this pull request the links related to LearnStorybook are updated to their proper place (https://storybook.js.org/tutorials/).

What was done:
- Links in the documentation pointing at LearnStorybook were updated to the correct place.


Feel free to provide feedback