### PR TITLE
Chore: (Docs) Remove references to master in the documentation

### DIFF
--- a/azure-pipelines.md
+++ b/azure-pipelines.md
@@ -17,7 +17,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
 
 #👇Event to trigger pipeline execution
 trigger:
-- master
+- main
 
 #👇Environment variables created for Chromatic
 variables:
@@ -75,7 +75,7 @@ If you need to customize your workflow to run Chromatic on specific branches, ad
 trigger:
   branches:
     include:
-    - master # 👈 Filters the execution to run only on the master branch
+    - main # 👈 Filters the execution to run only on the main branch
     exclude:
     - example
 
@@ -83,7 +83,7 @@ trigger:
 pr:
   branches:
     include:
-    - master # 👈 Filters the execution to run only on the pull requests for the master branch
+    - main # 👈 Filters the execution to run only on the pull requests for the main branch
     exclude:
     - example
 
@@ -95,7 +95,7 @@ pr:
 Read the official Azure <a href="https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops">conditional pipeline documentation</a>.
 </div>
 
-Now your pipeline will only run Chromatic in the `master` branch.
+Now your pipeline will only run Chromatic in the `main` branch.
 
 ### UI Test and UI Review
 
@@ -141,14 +141,14 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new build) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
 
-#### Azure squash/rebase merge and the "master" branch
+#### Azure squash/rebase merge and the "main" branch
 
 Azure's squash/rebase merge functionality creates new commits that have no association to the branch being merged. If you are already using this option, then we will automatically detect this situation and bring baselines over (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
@@ -170,13 +170,13 @@ stages:
     steps:
       # Other steps in the pipeline
 
-      #👇Checks if the branch is master and runs Chromatic with the flag to accept all changes.
+      #👇Checks if the branch is main and runs Chromatic with the flag to accept all changes.
     - task: CmdLine@2
       displayName: Publish to Chromatic and auto accept changes
-      condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
+      condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
       inputs:
         script: npx chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes
-      #👇 Checks if the branch is not master and runs Chromatic
+      #👇 Checks if the branch is not main and runs Chromatic
     - task: CmdLine@2
       displayName: Publish to Chromatic
       condition: eq(variables['Build.Reason'], 'PullRequest')
@@ -188,7 +188,7 @@ stages:
 Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 </div>
 
-Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `master` branch.
+Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `main` branch.
 
 If you want to test the changes introduced by the rebased branch, you can adjust your workflow and include a new step with the `ignore-last-build-on-branch` flag. For example:
 
@@ -231,7 +231,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Renovate automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Renovate automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `renovate` branches, use the following:
 

--- a/bitbucket-pipelines.md
+++ b/bitbucket-pipelines.md
@@ -98,14 +98,14 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new build) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
 
-#### BitBucket squash/rebase merge and the "master" branch
+#### BitBucket squash/rebase merge and the "main" branch
 
 BitBucket's squash/rebase merge functionality creates new commits that have no association to the branch being merged. If you are already using this option, then we will automatically detect this situation and bring baselines over (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
@@ -117,7 +117,7 @@ If you’re using this functionality but notice the incoming changes were not ac
 # A sample pipeline implementation
 pipelines:
   default:
-      # 👇 Checks if the branch is master and runs Chromatic with the flag to accept all changes.
+      # 👇 Checks if the branch is main and runs Chromatic with the flag to accept all changes.
     - step:
         name: 'Publish to Chromatic and auto accept changes'
         caches:
@@ -125,7 +125,7 @@ pipelines:
         script:
           - yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes
   pull-requests:
-    # 👇 Checks if the branch is not master and runs Chromatic
+    # 👇 Checks if the branch is not main and runs Chromatic
     your-branch:
       - step:
           name: 'Publish to Chromatic'
@@ -138,7 +138,7 @@ pipelines:
 Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 </div>
 
-Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `master` branch.
+Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `main` branch.
 
 If you want to test the changes introduced by the rebased branch, you can adjust your workflow and include a new step with the `ignore-last-build-on-branch` flag. For example:
 
@@ -186,9 +186,9 @@ pipelines:
             - node
           script:
               # 👇 Brings over the changes from the BitBucket repo
-            - git fetch origin master:master
+            - git fetch origin main:main
               # 👇 Option to update the build based on the changes obtained
-            - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --patch-build=$your-branch...master
+            - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --patch-build=$your-branch...main
 ```
 
 Including the `git` command prior to running Chromatic prevents unwanted build errors when Chromatic retrieves the information from your BitBucket repo.
@@ -212,7 +212,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Renovate automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Renovate automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `renovate` branches, use the following:
 

--- a/branching-and-baselines.md
+++ b/branching-and-baselines.md
@@ -28,7 +28,7 @@ That means once a snapshot is accepted as a baseline, it won’t need to be re-a
 
 Chromatic's [UI Tests](test) compare snapshots to a baseline: the last known “good” state of the story. Each story has its own baseline that is tracked independently on each branch.
 
-When you accept a snapshot you also update the baseline for that story on that branch. When you merge that branch into another (for instance back into `master`), the baseline comes with it. [Learn how we calculate baselines »](#how-baselines-are-calculated)
+When you accept a snapshot you also update the baseline for that story on that branch. When you merge that branch into another (for instance back into `main`), the baseline comes with it. [Learn how we calculate baselines »](#how-baselines-are-calculated)
 
 ## Branches
 
@@ -44,7 +44,7 @@ When you merge two branches together, Chromatic can sometimes have two (or more)
 
 #### Rebasing
 
-If you rebase a branch (say updating to branch off the latest commit off `master`), then you create a new commit that isn't a git descendent of the previous (pre-rebase) commit on that branch. Conceptually, that might mean that Chromatic should throw away any approvals that were made for builds on the branch, however this is probably not what you want.
+If you rebase a branch (say updating to branch off the latest commit off `main`), then you create a new commit that isn't a git descendent of the previous (pre-rebase) commit on that branch. Conceptually, that might mean that Chromatic should throw away any approvals that were made for builds on the branch, however this is probably not what you want.
 
 For this reason, we _always_ include accepted baselines from the latest build on the current branch, regardless of git history. You can bypass this with the `--ignore-last-build-on-branch=<branch-name>` flag of `chromatic`. For example:
 

--- a/circleci.md
+++ b/circleci.md
@@ -128,13 +128,13 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new build) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
-#### Squash/rebase merge and the "master" branch
+#### Squash/rebase merge and the "main" branch
 
 We use GitHub, GitLab, and Bitbucket APIs respectively to detect squashing and rebasing so your baselines match your expectations no matter your Git workflow  (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
@@ -145,12 +145,12 @@ If you’re using this functionality but notice the incoming changes were not ac
 
 # Other required configuration
 
-# 👇 Checks if the current branch is not the master and runs Chromatic
-if [ "${CIRCLE_BRANCH}" != "master" ];
+# 👇 Checks if the current branch is not the main and runs Chromatic
+if [ "${CIRCLE_BRANCH}" != "main" ];
 then
   yarn chromatic --project-token=CHROMATIC_PROJECT_TOKEN
 else
-  # 👇 Checks if the current branch is master and runs Chromatic with the flag to accept all changes
+  # 👇 Checks if the current branch is main and runs Chromatic with the flag to accept all changes
   yarn chromatic --project-token=CHROMATIC_PROJECT_TOKEN --auto-accept-changes
 fi
 ```
@@ -159,7 +159,7 @@ fi
 Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 </div>
 
-Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `master` branch.
+Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `main` branch.
 
 If you want to test the changes introduced by the rebased branch, you can adjust your workflow and include a new step with the `ignore-last-build-on-branch` flag. For example:
 
@@ -195,7 +195,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `dependabot` branches, use the following:
 

--- a/composition.md
+++ b/composition.md
@@ -48,7 +48,7 @@ Depending on your use case, you may want to compose Storybook using a [permalink
 
 #### Branch: `https://<branch>--<appid>.chromatic.com`
 
-If you want your local Storybook to compose the latest Storybook on `master`, use the branch permalink. This is useful for folks who work on multiple Storybooks simultaneously.
+If you want your local Storybook to compose the latest Storybook on `main`, use the branch permalink. This is useful for folks who work on multiple Storybooks simultaneously.
 
 - Building a component library in React and Vue at the same time
 - Monorepos with multiple inter-connected Storybook projects

--- a/custom-ci-provider.md
+++ b/custom-ci-provider.md
@@ -62,13 +62,13 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new build) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
-#### Squash/rebase merge and the "master" branch
+#### Squash/rebase merge and the "main" branch
 
 We use GitHub, GitLab, and Bitbucket APIs respectively to detect squashing and rebasing so your baselines match your expectations no matter your Git workflow  (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
@@ -80,10 +80,10 @@ If you’re using this functionality but notice the incoming changes were not ac
 # Your custom CI implementation 
 
 - run:
-    # 👇 Checks if the current branch is not master and runs Chromatic
-    if: branch != master
+    # 👇 Checks if the current branch is not main and runs Chromatic
+    if: branch != main
       command: npm run chromatic --project-token=CHROMATIC_PROJECT_TOKEN 
-    # 👇 Checks if the current branch is master and accepts all changes in Chromatic
+    # 👇 Checks if the current branch is main and accepts all changes in Chromatic
     else:
       command: npm run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes 
 ```
@@ -92,7 +92,7 @@ If you’re using this functionality but notice the incoming changes were not ac
 Read our official <a href="/docs/cli#chromatic-options">CLI documentation</a>.
 </div>
 
-Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally you'll maintain a clean `master` branch.
+Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally you'll maintain a clean `main` branch.
 
 #### Run Chromatic on external forks of open source projects
 
@@ -104,7 +104,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `dependabot` branches, use the following:
 

--- a/document.md
+++ b/document.md
@@ -42,7 +42,7 @@ Chromatic generates a [permalink](permalinks) for the latest uploaded Storybook 
 
 When you're linking to a library or component on Chromatic, it can be useful to link to the latest version on a `branch` rather than a specific build. To do so, add the `branch=foo` query parameter the the url.
 
-**Example**: `https://www.chromatic.com/library?appId=...&branch=master`.
+**Example**: `https://www.chromatic.com/library?appId=...&branch=main`.
 
 ---
 

--- a/github-actions.md
+++ b/github-actions.md
@@ -158,7 +158,7 @@ Other branches can also be included such as the ones created by the Renovate bot
 
 GitHub's Actions like other CI systems can run based on any type of event. Our recommendation is to run the Chromatic's step on `push` events. All other event types except `pull-request` will not work. 
 
-The `pull-request` event requires special consideration. Like other CI systems, GitHub allows workflow execution on either commits pushed to a branch in a pull request. Or for "merge" commits between that branch and the base branch (master).
+The `pull-request` event requires special consideration. Like other CI systems, GitHub allows workflow execution on either commits pushed to a branch in a pull request. Or for "merge" commits between that branch and the base branch (main).
 
 These specific types of commits (merge) don't persist in the history of your repository. That can cause Chromatic's baselines to be lost in certain situations. Hence why we recommend running Chromatic's step on `push`.
 
@@ -202,13 +202,13 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new run) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
-#### GitHub squash/rebase merge and the "master" branch
+#### GitHub squash/rebase merge and the "main" branch
 
 GitHub's squash/rebase merge functionality creates new commits that have no association to the branch being merged. If you've enabled our GitHub application in the [UI Review](review) workflow, then we will automatically detect this situation and bring baselines over (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
@@ -224,18 +224,18 @@ jobs:
     steps:
         # Other steps
       
-        # 👇 Checks if the branch is not master and runs Chromatic
+        # 👇 Checks if the branch is not main and runs Chromatic
       - name: Publish to Chromatic
-        if: github.ref != 'refs/heads/master' 
+        if: github.ref != 'refs/heads/main' 
         uses: chromaui/action@v1
         # Required options for the Chromatic GitHub Action
         with:
           token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
-        # 👇 Checks if the branch is master and accepts all changes in Chromatic
+        # 👇 Checks if the branch is main and accepts all changes in Chromatic
       - name: Publish to Chromatic and auto accept changes
-        if: github.ref == 'refs/heads/master' 
+        if: github.ref == 'refs/heads/main' 
         uses: chromaui/action@v1
         # Required options for the Chromatic GitHub Action
         with:
@@ -250,7 +250,7 @@ jobs:
 Read about the <a href="#available-options">available options</a>.
 </div>
 
-Including the `autoAcceptChanges` option ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `master` branch.
+Including the `autoAcceptChanges` option ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `main` branch.
 
 If you want to test the changes introduced by the rebased branch, you can adjust your workflow and include a new step with the `ignoreLastBuildOnBranch` option. For example:
 
@@ -289,7 +289,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `dependabot` branches, use the following:
 

--- a/gitlab.md
+++ b/gitlab.md
@@ -63,7 +63,7 @@ chromatic_publish:
   script:
     - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN
     
-  #👇Filters the execution to run only on the master branch.
+  #👇Filters the execution to run only on the main branch.
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always
@@ -73,7 +73,7 @@ chromatic_publish:
 Read the official GitLab <a href="https://docs.gitlab.com/ee/ci/yaml/#rules">conditional pipeline documentation</a>.
 </div>
 
-Now your pipeline will only run Chromatic in the `master` branch.
+Now your pipeline will only run Chromatic in the `main` branch.
 
 ### UI Test and UI Review
 
@@ -112,14 +112,14 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new build) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
 
-#### GitLab squash/rebase merge and the "master" branch
+#### GitLab squash/rebase merge and the "main" branch
 
 Azure's squash/rebase merge functionality creates new commits that have no association to the branch being merged. If you are already using this option, then we will automatically detect this situation and bring baselines over (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
@@ -134,7 +134,7 @@ If you’re using this functionality but notice the incoming changes were not ac
 stages:
   - test
 
- #👇Checks if the branch is master and runs Chromatic with the flag to accept all changes.
+ #👇Checks if the branch is main and runs Chromatic with the flag to accept all changes.
 chromatic_publish_auto_accept_changes:
   stage: test
   script:
@@ -143,7 +143,7 @@ chromatic_publish_auto_accept_changes:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always
 
- #👇Checks if the branch is not master and runs Chromatic
+ #👇Checks if the branch is not main and runs Chromatic
 chromatic_publish:
   stage: test
   script:
@@ -158,7 +158,7 @@ chromatic_publish:
 Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 </div>
 
-Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `master` branch.
+Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `main` branch.
 
 If you want to test the changes introduced by the rebased branch, you can adjust your workflow and include a new step with the `ignore-last-build-on-branch` flag. For example:
 
@@ -196,7 +196,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Renovate automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Renovate automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `renovate` branches, use the following:
 

--- a/jenkins.md
+++ b/jenkins.md
@@ -77,7 +77,7 @@ Now your pipeline will only run Chromatic in the `example` branch.
 
 ### Recommended configuration for build events
 
-Jenkins like CI systems offer the option of running builds for various types of events. For instance for commits pushed to a branch in a pull request. Or for "merge" commits between that branch and the base branch (master).
+Jenkins like CI systems offer the option of running builds for various types of events. For instance for commits pushed to a branch in a pull request. Or for "merge" commits between that branch and the base branch (main).
 
 These specific types of commits (merge) don't persist in the history of your repository. That can cause Chromatic's baselines to be lost in certain situations.
 
@@ -131,13 +131,13 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new build) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
-#### Squash/rebase merge and the "master" branch
+#### Squash/rebase merge and the "main" branch
 
 
 We use GitHub, GitLab, and Bitbucket APIs respectively to detect squashing and rebasing so your baselines match your expectations no matter your Git workflow (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
@@ -153,11 +153,11 @@ pipeline {
   stages {
     /* Other pipeline stages */
     
-    /* 👇 Checks if the current branch is not master and runs Chromatic */
+    /* 👇 Checks if the current branch is not main and runs Chromatic */
     stage('Publish to Chromatic') {
       when { 
         not { 
-          branch 'master' 
+          branch 'main' 
         } 
       }
       environment {
@@ -167,10 +167,10 @@ pipeline {
          sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}" 
       }
     }
-    /* 👇 Checks if the current branch is master and runs Chromatic with the flag to accept all changes */
+    /* 👇 Checks if the current branch is main and runs Chromatic with the flag to accept all changes */
     stage('Publish to Chromatic and auto accept changes') {
       when { 
-         branch 'master'
+         branch 'main'
       }
       environment {
         CHROMATIC_PROJECT_TOKEN = 'Chromatic project token'
@@ -187,7 +187,7 @@ pipeline {
 Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 </div>
 
-Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `master` branch.
+Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `main` branch.
 
 If you want to test the changes introduced by the rebased branch, you can adjust your workflow and include a new step with the `ignore-last-build-on-branch` flag. For example:
 
@@ -232,7 +232,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `dependabot` branches, use the following:
 

--- a/monorepos.md
+++ b/monorepos.md
@@ -18,7 +18,7 @@ You can only have one linked project in Chromatic for any given repository, so i
 
 ### Combine multiple projects into a single Storybook
 
-A common approach that works well for many teams is to combine multiple subproject's Storybooks into a single master Storybook. When you run Chromatic on the master Storybook you test all stories in a singe Chromatic project.
+A common approach that works well for many teams is to combine multiple subproject's Storybooks into a single Storybook. When you run Chromatic on the principal Storybook you test all stories in a singe Chromatic project.
 
 For example, you could write in your `.storybook/main.js`:
 

--- a/permalinks.md
+++ b/permalinks.md
@@ -18,7 +18,7 @@ Before we begin, find your project's unique app id. Go to the permalink section 
 
 ## Build your own permalink
 
-Build your own permalinks to get more flexibility. For example, link to the `master` branch of Storybook in your external documentation site. Or link to a specific Storybook version (via commit) for [Composition](composition).
+Build your own permalinks to get more flexibility. For example, link to the `main` branch of Storybook in your external documentation site. Or link to a specific Storybook version (via commit) for [Composition](composition).
 
 | Permalink   | Format                                        |
 | ----------- | --------------------------------------------- |

--- a/review.md
+++ b/review.md
@@ -107,8 +107,8 @@ Similar to [GitHub code review](https://github.com/features/code-review/), Chrom
 
 The process might look something like:
 
-1. Create a new PR to `master` adding Chromatic to CI
+1. Create a new PR to `main` adding Chromatic to CI
 1. Merge that PR when everything works well.
-1. Update your existing feature PR(s) w/ the latest from `master` (either merge or rebase from master).
+1. Update your existing feature PR(s) w/ the latest from `main` (either merge or rebase from main).
 
 </details>

--- a/test.md
+++ b/test.md
@@ -65,7 +65,7 @@ Sometimes you need a closer look to determine why a snapshot is rendering as it 
 <details>
 <summary>How are changes on builds different from those listed on the PR Screen 'Changeset' tab?</summary>
 
-UI tests (shown on the build screen) detect changes between builds, specifically, between the last accepted baseline and the latest build. This is useful for detecting defects during the development process and when merging to master to ship.
+UI tests (shown on the build screen) detect changes between builds, specifically, between the last accepted baseline and the latest build. This is useful for detecting defects during the development process and when merging to the main branch to ship.
 
 In contrast, the PR screen shows the changeset between the latest commit on the PR branch (head) and the 'merge base' (base). Think of it like code review, but for UI.
 

--- a/travisci.md
+++ b/travisci.md
@@ -57,7 +57,7 @@ Read the official Travis CI <a href="https://docs.travis-ci.com/user/conditional
 
 ### Recommended configuration for build events
 
-Travis CI like other CI systems offer the option of running builds for various types of events. For instance for commits pushed to a branch in a pull request. Or for "merge" commits between that branch and the base branch (master).
+Travis CI like other CI systems offer the option of running builds for various types of events. For instance for commits pushed to a branch in a pull request. Or for "merge" commits between that branch and the base branch (main).
 
 These specific types of commits (merge) don't persist in the history of your repository. That can cause Chromatic's baselines to be lost in certain situations. 
 
@@ -119,13 +119,13 @@ Builds that contain visual changes need to be [verified](test#verify-ui-changes)
 
 If you deny any change, you will need to make the necessary code changes to fix the test (and thus start a new build) to get Chromatic to pass again.
 
-#### Maintain a clean "master" branch
+#### Maintain a clean "main" branch
 
-A clean `master` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `master` branch are passing.
+A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
-If the builds are a result of direct commits to `master`, you will need to accept changes to keep master clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `master`.
+If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
 
-#### Squash/rebase merge and the "master" branch
+#### Squash/rebase merge and the "main" branch
 
 We use GitHub, GitLab, and Bitbucket APIs respectively to detect squashing and rebasing so your baselines match your expectations no matter your Git workflow (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
@@ -138,13 +138,13 @@ If you’re using this functionality but notice the incoming changes were not ac
 
 jobs:
   include:
-     # 👇 Checks if the branch is not master and runs Chromatic
+     # 👇 Checks if the branch is not main and runs Chromatic
    - name: 'Publish to Chromatic'
-     if: branch != master 
+     if: branch != main 
      script: yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}
-     # 👇 Checks if the branch is master and runs Chromatic with the flag to accept all changes
+     # 👇 Checks if the branch is main and runs Chromatic with the flag to accept all changes
    - name: 'Publish to Chromatic and auto accepts changes'
-     if: branch = master
+     if: branch = main
      script: yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes
 ```
 
@@ -152,7 +152,7 @@ jobs:
 Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 </div>
 
-Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `master` branch.
+Including the `--auto-accept-changes` flag ensures all incoming changes will be accepted as baselines. Additionally, you'll maintain a clean `main` branch.
 
 If you want to test the changes introduced by the rebased branch, you can adjust your workflow and include a new step with the `ignore-last-build-on-branch` flag. For example:
 
@@ -188,7 +188,7 @@ There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others 
 
 Sometimes you might want to skip running a build for a certain branch, but still have Chromatic mark the latest commit on that branch as "passed". Otherwise pull requests could be blocked due to required checks that remain pending. To avoid this issue, you can run `chromatic` with the `--skip` flag. This flag accepts a branch name or glob pattern.
 
-One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `master` or `develop` branch.
+One use case for this feature is skipping builds for branches created by a bot. For instance, Dependabot automatically updates a projects dependencies. Although some dependencies can result in UI changes, you might not find it worthwhile to run Chromatic for every single dependency update. Instead, you could rely on Chromatic running against the `main` or `develop` branch.
 
 To skip builds for `dependabot` branches, use the following:
 


### PR DESCRIPTION
With this pull request the documentation was updated to remove references to master turning them into main when addressing branches.

Feel free to provide feedback