### PR TITLE
Document how to use `disableStories` and limit stories w/ preserve missing

### DIFF
--- a/ignoring-elements.md
+++ b/ignoring-elements.md
@@ -21,7 +21,8 @@ pixels within the bounding rectangle of ignored elements. It's important to ensu
 
 ## Ignore stories
 
-You can omit stories entirely from Chromatic testing using the `disable` [story parameter](https://storybook.js.org/docs/react/writing-stories/parameters#story-parameters):
+If you have a story you do not wish to snapshot in Chromatic, you can disable snapshotting with the
+`disableSnapshot` [story parameter](https://storybook.js.org/docs/react/writing-stories/parameters#story-parameters):
 
 ```js
 // MyComponent.stories.js | MyComponent.stories.ts
@@ -36,26 +37,25 @@ const Template = (args) => <MyComponent {...args} />;
 
 export const StoryName = Template.bind({});
 StoryName.parameters = {
-  // disables Chromatic on a story level
-  chromatic: { disable: true },
+  // disables Chromatic's snapshotting on a story level
+  chromatic: { disableSnapshot: true },
 };
 ```
 
+If you want to adopt snapshotting incrementally, you can use Storybook's parameter inheritance to whitelist stories.
 
-If you want to adopt Chromatic incrementally, you can use Storybook's parameter inheritance to whitelist stories.
-
-In your [`.storybook/preview.js`](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering) add the `disable` option in the [parameters](https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters):
+In your [`.storybook/preview.js`](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering) add the `disableSnapshot` option in the [parameters](https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters):
 
 ```js
 // .storybook/preview.js
 
 export const parameters = {
-  // disables Chromatic on a global level
-  chromatic: { disable: true },
+  // disables snapshotting on a global level
+  chromatic: { disableSnapshot: true },
 };
 ```
 
-In the component's stories you'd like to enable Chromatic:
+In the component's stories you'd like to enable snapshotting:
 
 ```js
 // MyComponent.stories.js | MyComponent.stories.ts
@@ -64,13 +64,13 @@ import MyComponent from './MyComponent';
 
 export default {
   component: MyComponent,
-  // enables Chromatic for the component
+  // enables snapshotting for the component
   parameters: {
-    chromatic: { disable: false },
+    chromatic: { disableSnapshot: false },
   },
 };
 
-const Template = (args) => <MyComponent {...args} />; 
+const Template = (args) => <MyComponent {...args} />;
 
 export const StoryName = Template.bind({});
 StoryName.args = {};

--- a/monorepos.md
+++ b/monorepos.md
@@ -55,3 +55,19 @@ If you want to get a Chromatic PR badge for such commits (for instance if you bl
 If you are combining your Storybooks into a single Storybook (see above), but you have detected only a subset of projects have changed, in order to avoid unnecessarily capturing unchanged stories, you can build a Storybook with a subset of your projects' stories.
 
 Ordinarily when you run a build that is missing a set of stories, Chromatic will treat those stories as deleted and the next build that includes them will have no baseline for them, and treat them as new. You can pass the `--preserve-missing` flag to your build to avoid this behavior. What this means is Chromatic will pass the baselines forward and treat all missing stories as "preserved" without re-capturing them.
+
+### Building a subset of your stories
+
+In order to build a Storybook with a subset of your stories, you can use an environment variable in `.storybook/main.js`:
+
+```js
+const storiesForProject = {
+  projectA: './projectA/**.stories.js',
+  projectB: './projectB/**.stories.js',
+  // etc
+};
+
+export default {
+  stories: storiesForProject[process.env.ONLY_STORYBOOK_PROJECT] || '**/*.stories.js',
+};
+```


### PR DESCRIPTION
For https://github.com/chromaui/chromatic/issues/4810

We shouldn't merge this until we do release 62.

Also @ghengeveld can you update the CLI section when you've updated the CLI flags.

cc @shilman. We should probably make this "build limited SB" a top-level feature in SB. Shopify have asked for it for instance.