### PR TITLE
Chore: (Docs) Adds section about env variables with GitHub Actions

### DIFF
--- a/github-actions.md
+++ b/github-actions.md
@@ -155,7 +155,7 @@ Other branches can also be included, such as the ones created by the Renovate bo
 
 ### Support for environment variables
 
-Environment variables are supported in Chromatic. But it comes with a tradeoff. We recommend that you prefix each environment variable with the `STORYBOOK` keyword and adjust your workflow to the following:
+Environment variables are supported in Chromatic. But it comes with a caveat. We recommend that you prefix each environment variable with the `STORYBOOK` keyword and adjust your workflow to the following:
 
 ```yml
 # .github/workflows/chromatic.yml


### PR DESCRIPTION
With this pull request, the GitHub Action is updated to include information about the usage of environment variables with Chromatic's GitHub Action.

Follows up on [this](https://app.asana.com/0/1197936409294778/1199981061353857/f) task

What was done:
- Polished the documentation a bit.
- Added a section about Environment variables.
- Fixed the options table (seems that it was being split into tables for some reason).


Feel free to provide feedback