### PR TITLE
Chore: (Docs) Updates docs for capture stack v3 (beta)

### DIFF
--- a/infrastructure-release-notes.md
+++ b/infrastructure-release-notes.md
@@ -6,6 +6,26 @@ description: Chromatic's browser infrastructure release notes
 
 # Chromatic Capture Cloud release notes
 
+## Version 3
+
+Welcome to `Chromatic Capture Cloud version 3` released June 2021.
+
+**Status**: Beta
+
+Key highlights on this release:
+
+- Chrome version updated to version 89
+
+### Supported browsers versions
+
+| Browser           | Version |
+| ----------------- | ------- |
+| Chrome            | 89      |
+| Firefox           | 65      |
+| Internet Explorer | 11      |
+
+---
+
 ## Version 2
 
 Welcome to `Chromatic Capture Cloud version 2` released December 2020.
@@ -19,7 +39,7 @@ Key highlights on this release:
 ### Supported browsers versions
 
 | Browser           | Version |
-|-------------------|---------|
+| ----------------- | ------- |
 | Chrome            | 84      |
 | Firefox           | 65      |
 | Internet Explorer | 11      |
@@ -39,7 +59,7 @@ Key highlights of this release:
 ### Supported browsers versions
 
 | Browser           | Version |
-|-------------------|---------|
+| ----------------- | ------- |
 | Chrome            | 73      |
 | Firefox           | 65      |
 | Internet Explorer | 11      |

--- a/infrastructure-upgrades.md
+++ b/infrastructure-upgrades.md
@@ -38,13 +38,12 @@ Future builds will use the upgrade build's auto-accepted baselines as the source
 
 ![Auto-accept changes](img/infrastructure-upgrades-auto-accept.png)
 
-
 ### Release notes for infrastructure upgrades
 
 Read about the infrastructure changes in the release notes.
 
-| Capture Stack version                                                |Status                                               | 
-|:--------------------------------------------------------------------:|-----------------------------------------------------|
-| [Version 2](infrastructure-release-notes#version-2)                  | General availability                                |
-| [Version 1](infrastructure-release-notes#version-1)                  | Outdated ([opt in for upgrade](#opt-in-to-upgrade)) |
-
+|                Capture Stack version                | Status                                                                                                                             |
+| :-------------------------------------------------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [Version 3](infrastructure-release-notes#version-3) | Beta (contact us through our <a class="intercom-concierge-bot">in-app chat</a> or [email](mailto:support@chromatic.com) to opt in) |
+| [Version 2](infrastructure-release-notes#version-2) | General availability                                                                                                               |
+| [Version 1](infrastructure-release-notes#version-1) | Outdated ([opt in for upgrade](#opt-in-to-upgrade))                                                                                |


### PR DESCRIPTION
With this pull request, the infrastructure documentation is updated to mention that Capture Stack v3 is out for beta.

Once it's out I'll update the docs and update its status.

This is based on the question I've asked @tmeasday during this week's company meeting.

Feel free to provide feedback.
