### PR TITLE
Chore: (Docs) Updates the capture stack v2 docs

### DIFF
--- a/infrastructure-release-notes.md
+++ b/infrastructure-release-notes.md
@@ -30,7 +30,7 @@ Key highlights on this release:
 
 Welcome to `Chromatic Capture Cloud version 2` released December 2020.
 
-**Status**: Outdated ([opt in for upgrade](infrastructure-upgrades#opt-in-to-upgrade))
+**Status**: No longer available
 
 Key highlights on this release:
 

--- a/infrastructure-upgrades.md
+++ b/infrastructure-upgrades.md
@@ -42,8 +42,8 @@ Future builds will use the upgrade build's auto-accepted baselines as the source
 
 Read about the infrastructure changes in the release notes.
 
-|                Capture Stack version                | Status                                                                                                                             |
-| :-------------------------------------------------: | ---------------------------------------------------------------------------------------------------------------------------------- |
-| [Version 3](infrastructure-release-notes#version-3) | General availability                                                                                                               |
-| [Version 2](infrastructure-release-notes#version-2) | Outdated ([opt in for upgrade](#opt-in-to-upgrade))                                                                                |
-| [Version 1](infrastructure-release-notes#version-1) | No longer available                                                                                                                |
+|                Capture Stack version                | Status               |
+| :-------------------------------------------------: | -------------------- |
+| [Version 3](infrastructure-release-notes#version-3) | General availability |
+| [Version 2](infrastructure-release-notes#version-2) | No longer available  |
+| [Version 1](infrastructure-release-notes#version-1) | No longer available  |


### PR DESCRIPTION
With this small pull request, the capture stack documentation and infrastructure upgrades are updated to inform customers that Capture stack v2 is no longer available. Follows up on #74 and addresses this [task](https://app.asana.com/0/1197936409294778/1200678597900481/f).

@tmeasday is it too soon on this and do we need to wait longer on this or are we good to go?

