### PR TITLE
Chore: Reverts the sidebar turbo snap addition

### DIFF
--- a/_includes/sidebar_nav.html
+++ b/_includes/sidebar_nav.html
@@ -192,9 +192,6 @@
       >
     </li>
     <li>
-      <a href="turbosnap" class="{% if page.title == "TurboSnap" %}active {% endif %}link">TurboSnap</a>
-    </li>
-    <li>
       <a
         href="open-source"
         class="{% if page.title == "Open source sponsorships" %}active {% endif %}link"


### PR DESCRIPTION
This pull request reverts back the addition of the turbosnap documentation on the sidebar.


