### PR TITLE
Chore: Introduces back turbo snap to the sidebar

### DIFF
--- a/_includes/sidebar_nav.html
+++ b/_includes/sidebar_nav.html
@@ -192,7 +192,7 @@
       >
     </li>
     <li>
-      <a href="turbosnap" class="{% if page.title == " TurboSnap" %}active {% endif %}link">TurboSnap</a>
+      <a href="turbosnap" class="{% if page.title == "TurboSnap" %}active {% endif %}link">TurboSnap</a>
     </li>
     <li>
       <a


### PR DESCRIPTION
With this pull request, the sidebar is updated to include the link to the turbosnap documentation.

What was done:
- The sidebar is updated to include the link to the documentation