### PR TITLE
Chore: (Docs) Infrastructure docs updates for CH-1579

### DIFF
--- a/browsers.md
+++ b/browsers.md
@@ -14,13 +14,13 @@ Go to the "Manage" screen and click to enable another browser. Chrome is enabled
 
 ![Enable firefox in Chromatic](img/browser-managescreen-enable-firefox.png)
 
-On the next test run, Chromatic will create baselines for the newly enabled browser. Previously accepted stories in Chrome will be auto-accepted as baselines in the new browser. You'll want to make sure your builds pass before enabling a new browser.
+Chromatic will create baselines for the newly enabled browser on the next test run. Previously accepted stories in Chrome will be auto-accepted as baselines in the new browser. You'll want to make sure your builds pass before enabling a new browser.
 
 <video autoPlay muted playsInline loop width="560px" class="center">
   <source src="img/browser-buildscreen-multiple-browsers-inprogress.mp4" type="video/mp4" />
 </video>
 
-The new browser's snapshots will be marked as "New" on the Build page and you will now be able to view it during review.
+The new browser's snapshots will be marked as "New" on the Build page, and you will now be able to view them during [review](review).
 
 ![New Firefox snapshot in Chromatic](img/browser-snapshotscreen-new-firefox-snapshot.jpg)
 
@@ -30,25 +30,25 @@ Your team can also see how a story renders in a given browser across different b
   <source src="img/browser-componentscreen-toggle-snapshots.mp4" type="video/mp4" />
 </video>
 
-Congratulations you enabled a new browser! From now on our Capture Cloud will spin up as many Chrome, Firefox, or IE11 machines as you need to test your Storybook in the least amount of time.
+Congratulations, you enabled a new browser! From now on, our Capture Cloud will spin up as many Chrome, Firefox, or IE11 machines as you need to test your Storybook in the least amount of time.
 
 ## Verify UI changes across browsers
 
-When Chromatic tests detect a visual change to a story in any enabled browser you'll get notified. For instance, if you have a `TooltipMessage:default` story that is tested in Chrome and Firefox, you'll be notified when changes happen in either Chrome or Firefox.
+When Chromatic tests detect a visual change to a story in any enabled browser, you'll get notified. For instance, if you have a `TooltipMessage:default` story tested in Chrome and Firefox, you'll get a notification when changes happen in either browser.
 
 ![Notification of changes in Firefox snapshot](img/browser-buildscreen-notification.jpg)
 
-You can see changes for the browser's snapshot in the review workflow.
+You can see changes for the browser's snapshot in the [review](review#find-your-pull-request) workflow.
 
 ![Changes in Firefox snapshot](img/browser-snapshotscreen-diff-in-firefox-snapshot.jpg)
 
-Once you accept changes to the story, its baselines are updated. Each story has one baseline for Chrome, it can also have baselines for Firefox and IE11.
+Once you accept changes to the story, its baselines are updated. Each story has one baseline for Chrome, and it can also have baselines for Firefox and IE11.
 
 <div class="aside">If you test responsiveness with the viewport parameters, baselines are associated with each viewport, and those can have a Chrome, Firefox, or IE11 baseline.</div>
 
 ## Browser upgrades
 
-Chromatic's infrastructure is periodically updated to use the the latest **stable** browser version (can be behind the latest version). When an infrastructure upgrade is available you're notified in the app.
+Chromatic's infrastructure is periodically updated to use the latest **stable** browser version (can be behind the latest version). When an infrastructure upgrade is available, you'll see a notification in your project's dashboard.
 
 Upgrades can cause subtle changes in story appearance due to the underlying rendering engine changes. We try to make upgrades as easy as possible by auto-migrating your test baselines. Learn more about [infrastructure upgrades](infrastructure-upgrades) and view [browser versions](infrastructure-release-notes).
 
@@ -59,8 +59,19 @@ Upgrades can cause subtle changes in story appearance due to the underlying rend
 <details>
 <summary>Does Chromatic tell me when snapshots are different between browsers?</summary>
 
-This has significant trade offs. Teams that try to verify consistency between browsers end up encountering false positives due to inherent browser/device/OS differences like anti-aliasing and font rendering. Or they require workarounds like loosening diff thresholds which result in false negatives.
+This has significant trade-offs. Teams that try to verify consistency across browsers end up encountering false positives due to inherent browser/device/OS differences (e.g., font rendering, anti-aliasing) or require workarounds like adjusting the [diff thresholds](threshold), resulting in false positives.
 
 Chromatic does not programmatically compare snapshots from different browsers against each other. Instead, we compare the snapshots for each browser against the baseline for that browser.
+
+</details>
+
+<details>
+<summary>Does Chromatic support specific browser versions?</summary>
+
+Chromatic does not support running tests on specific browser versions. While building Chromatic's Capture Cloud, we found that not all browser versions are created equal. Some contain bugs that lead to rendering inconsistencies. We aim to take care of these details so that you don't have to, giving you consistently flake-free tests.
+
+We extensively test new browser versions and modify our infrastructure to handle well-known inconsistencies between them. Our goal is to provide you with the latest stable version of each of our supported browsers on a timely schedule with a painless upgrade experience between them.
+
+That said, we don't support outdated browser versions since our users are [automatically upgraded](infrastructure-upgrades#how-to-upgrade-your-project) to the latest versions after the upgrade window ends, simplifying your infrastructure and customer support.
 
 </details>

--- a/infrastructure-upgrades.md
+++ b/infrastructure-upgrades.md
@@ -54,12 +54,11 @@ Read about the infrastructure changes in the release notes.
 ### Frequently asked questions
 
 <details>
-<summary>Does Chromatic support specific browser versions?</summary>
+<summary>Can I run tests on a specific browser version?</summary>
 
-Chromatic does not support running tests on specific browser versions. While building Chromatic's Capture Cloud, we found that not all browser versions are created equal. Some contain bugs that lead to rendering inconsistencies. We aim to take care of these details so that you don't have to, giving you consistently flake-free tests.
+Chromatic does not support running tests on specific browser versions.
+With each infrastructure upgrade, our goal is to provide you with the latest stable browser versions, enabling a consistently flake-free testing environment while simplifying our infrastructure and customer support.
 
-We extensively test new browser versions and modify our infrastructure to handle well-known inconsistencies between them. Our goal is to provide you with the latest stable version of each of our supported browsers on a timely schedule with a painless upgrade experience between them.
-
-That said, we don't support outdated browser versions since our users are [automatically upgraded](#how-to-upgrade-your-project) to the latest versions after the upgrade window ends, simplifying your infrastructure and customer support.
+Read our [documentation](browsers) to learn more about enabling additional browsers.
 
 </details>


### PR DESCRIPTION
With this pull request, the documentation is updated to address and close [CH-1579](https://linear.app/chromaui/issue/CH-1579/chromatic-infrastructure-docs).

What was done:
- Moved the browser information from the browsers and placed it in Infrastructure docs
- Polished the Infrastructure docs.

Feel free to provide feedback