### PR TITLE
Update github action code samples to not require the github token

### DIFF
--- a/github-actions.md
+++ b/github-actions.md
@@ -36,7 +36,6 @@ jobs:
         uses: chromaui/action@v1
         # Chromatic GitHub Action options
         with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
 ```
@@ -117,7 +116,6 @@ jobs:
         uses: chromaui/action@v1
         # Options required to the GitHub Chromatic Action
         with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
 ```
@@ -139,7 +137,7 @@ If you need to customize your workflow to run Chromatic on specific branches, ad
 on:
   push:
     branches-ignore:
-      - "example" # 👈 Excludes the example branch
+      - 'example' # 👈 Excludes the example branch
 
 jobs:
 # The list of jobs and steps
@@ -188,7 +186,6 @@ jobs:
         # Options required for Chromatic's GitHub Action
         with:
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         env:
           #👇 Sets the environment variable
           CHROMATIC_RETRIES: 5
@@ -216,7 +213,6 @@ jobs:
         # Options required for Chromatic's GitHub Action
         with:
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         env:
           #👇 Sets the environment variable
           STORYBOOK_SOME_ENV_VAR: {% raw %}${{ secrets.STORYBOOK_SOME_ENV_VAR }} {% endraw %}
@@ -255,7 +251,6 @@ jobs:
         uses: chromaui/action@v1
         # Options required to the GitHub chromatic action
         with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
           exitZeroOnChanges: true # 👈 Option to prevent the workflow from failing
@@ -301,7 +296,6 @@ jobs:
         uses: chromaui/action@v1
         # Required options for the Chromatic GitHub Action
         with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
         # 👇 Checks if the branch is main and accepts all changes in Chromatic
@@ -310,7 +304,6 @@ jobs:
         uses: chromaui/action@v1
         # Required options for the Chromatic GitHub Action
         with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
           autoAcceptChanges: true # 👈 Option to accept all changes
@@ -338,7 +331,6 @@ jobs:
         uses: chromaui/action@v1
         # Options required to the GitHub chromatic action
         with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
           ignoreLastBuildOnBranch: 'my-branch' # 👈 Option to skip the last build on target branch

--- a/turbosnap.md
+++ b/turbosnap.md
@@ -65,7 +65,6 @@ steps:
   - name: Publish to Chromatic
     uses: chromaui/action@v1
     with:
-      token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
       projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
       onlyChanged: true
 ```
@@ -251,8 +250,8 @@ If you have a large dependency tree, the build process may fail due to an out of
 
 <details>
   <summary>Why do merge commits test more changes that I expect?</summary>
-  
-  Ordinarily, TurboSnap uses git to find all files that have changed since the <a href="/branching-and-baselines#calculating-the-ancestor-builds">ancestor build</a> to determine which components/stories to snapshot. The changed file behavior is more complex with merge commits because there are two "ancestor builds".
+
+Ordinarily, TurboSnap uses git to find all files that have changed since the <a href="/branching-and-baselines#calculating-the-ancestor-builds">ancestor build</a> to determine which components/stories to snapshot. The changed file behavior is more complex with merge commits because there are two "ancestor builds".
 
 When you have a merge commit, Chromatic considers **any file that has changed since either ancestor's commit** to decide if a story needs to be re-snapshotted. In other words, the union of the git changes.
 


### PR DESCRIPTION
It seems that the Chromatic action no longer requires the github token. Updated the code samples to reflect this:
https://linear.app/chromaui/issue/CH-1052/github-token-is-possibly-not-necessary-anymore