### PR TITLE
Clarify how/why collaborators work in the Figma plugin

### DIFF
--- a/figma.md
+++ b/figma.md
@@ -6,7 +6,7 @@ description: Connect stories to variants
 
 # Figma plugin (beta)
 
-Storybook Connect is a Figma plugin that allows you to link stories to Figma components. Once connected, you can view your live stories in the design workspace without leaving Figma.
+Storybook Connect is a Figma plugin that allows you to link stories to Figma components. Once linked, you can view your live stories in the design workspace without leaving Figma.
 
 <video autoPlay muted playsInline loop width="560px" class="center" style="pointer-events: none;">
   <source src="img/figma-plugin-overview.mp4" type="video/mp4" />
@@ -18,21 +18,29 @@ Storybook Connect is a Figma plugin that allows you to link stories to Figma com
 2. Open the plugin. Use the command palette in Figma `command + /` then type `Storybook Connect`. ![Open Storybook Connect in Figma](img/figma-plugin-open-in-figma.png)
 3. Follow the installation instructions to authenticate with Chromatic.
 
-### Connect a story to a Figma component
+### Link a story to a Figma component
 
-1. Select a Figma component to connect. The plugin supports connecting stories to Figma components, variants, and instances. It does not support connecting stories to layers. ![Select component](img/figma-plugin-select-component.png)
+1. Select a Figma component to link. The plugin supports linking stories to Figma components, variants, and instances. It does not support linking stories to layers. ![Select component](img/figma-plugin-select-component.png)
 
 2. Navigate to a story in a Storybook published on Chromatic. Make sure it's on the branch you want to link. Then copy the URL to the story. ![Copy story url](img/figma-plugin-copy-url.png)
 
 3. Paste the URL into the plugin’s form field. ![Paste story url](img/figma-plugin-paste-url.png)
 
-4. Once connected, the component and its instances will all have links in the sidebar to view the corresponding story. ![Figma sidebar view](img/figma-plugin-sidebar-view.png)
+4. Once linked, the component and its instances will all have links in the sidebar to view the corresponding story. ![Figma sidebar view](img/figma-plugin-sidebar-view.png)
 
 ### Open a story in Figma
 
-1. Select the component that you've previously connected in Figma.
+1. Select the component that you've previously linked in Figma.
 2. Then navigate to Figma’s Design sidebar and click the “View story” action. Alternatively, open the plugin by using the command palette `command + /` then type the name `Storybook Connect`.
 
 <video autoPlay muted playsInline loop width="560px" class="center" style="pointer-events: none;">
   <source src="img/figma-plugin-open-story.mp4" type="video/mp4" />
 </video>
+
+### Collaborators
+
+When a story is linked to a Figma component, that link persists across teams and Figma files. Only [collaborators](collaborators) can find and access linked components for security purposes.
+
+Invite non-technical teammates like designers or PMs to your Chromatic project as [external collaborators](collaborators#external-collaborators). That gives them permissions to view and manage linked components.
+
+Every Chromatic plan comes with unlimited collaborators and [fine-grained roles](collaborators#roles). There are no extra charges "per seat".


### PR DESCRIPTION
We've gotten questions about why collaborators (like designers) need to sign up with Chromatic a few times. This update clarifies the behavior to set expectations.