### PR TITLE
Mention SOC2 in our /security page

### DIFF
--- a/security.md
+++ b/security.md
@@ -8,6 +8,10 @@ description: Security overview and responsible disclosure
 
 Our priority is securing your intellectual property and sensitive information. Download an overview (PDF) of our security policy [here](assets/Chroma-Security-Policy.pdf).
 
+## SOC 2
+
+Chromatic is [SOC 2 Type 1](https://us.aicpa.org/interestareas/frc/assuranceadvisoryservices/serviceorganization-smanagement) compliant. This rigorous, independent assessment of our internal security controls serves as validation of our dedication to the highest standards for security, availability, and confidentiality.
+
 ## Responsible disclosure
 
 Our team is vigilant about adhering to security best practices. But we're not so naive to believe that we're perfect. Security is a priority – we'll act quickly to address verifiable security issues.


### PR DESCRIPTION
We are now SOC2 type 1 compliant. This PR updates the /security page to say so.