### PR TITLE
Chore: (Docs) Fixes focus story play function

### DIFF
--- a/hoverfocus.md
+++ b/hoverfocus.md
@@ -226,6 +226,6 @@ WithFocusState.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
 
   // Looks up the button and interacts with it.
-  canvas.getByRole("button").focus();
+  await canvas.getByRole("button").focus();
 };
 ```


### PR DESCRIPTION
With this small pull request, the focus story defined in the `hoverfocus` documentation is fixed to prevent issues with Chromatic. Addresses the following [conversation](https://chromaticqa.slack.com/archives/CKV1LSC4D/p1658406981043589)