### PR TITLE
Chore: (Docs): Adds zip option to CI documentation

### DIFF
--- a/azure-pipelines.md
+++ b/azure-pipelines.md
@@ -97,6 +97,34 @@ Read the official Azure <a href="https://docs.microsoft.com/en-us/azure/devops/p
 
 Now your pipeline will only run Chromatic in the `main` branch.
 
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend adjusting your pipeline and run the `chromatic` command with the `--zip` flag to compress your build before uploading it. For example:
+
+```yml
+# azure-pipelines.yml
+
+# Other configurations
+
+# Pipeline stages
+stages:
+- stage: Test
+  displayName: Chromatic Testing
+  # Job list
+  jobs:
+  - job: Chromatic_Deploy
+    displayName: Publish to Chromatic
+    steps:
+      # Other steps in the pipeline
+
+      #👇Adds Chromatic as a step in the pipeline
+    - task: CmdLine@2
+      displayName: Publish to Chromatic
+      inputs:
+        #👇Runs Chromatic with the flag to compress the build output.
+        script: npx chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --zip
+```
+
 ### Overriding Chromatic's branch detection
 
 If your Azure pipeline includes a set of rules for branches (e.g., renames the branch, creates ephemeral, or temporary branches) it can lead to unforeseen build errors.

--- a/bitbucket-pipelines.md
+++ b/bitbucket-pipelines.md
@@ -30,6 +30,7 @@ pipelines:
             # 👇 Runs Chromatic
           - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN
 ```
+
 <div class="aside">
 For extra security, add Chromatic's <code>project-token</code> as an environment variable. See the official BitBucket <a href="https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/">environment variables documentation</a>.
 </div>
@@ -60,6 +61,28 @@ Read the official BitBucket <a href="https://support.atlassian.com/bitbucket-clo
 
 Now your pipeline will only run Chromatic in the `main` branch.
 
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend adjusting your pipeline and run the `chromatic` command with the `--zip` flag to compress your build before uploading it. For example:
+
+```yml
+# bitbucket-pipelines.yml
+
+# A sample pipeline implementation
+pipelines:
+  default:
+    # Other steps in the pipeline
+
+    # 👇 Adds Chromatic as a step in the pipeline
+    - step:
+        name: "Publish to Chromatic"
+        # Other pipeline configuration
+        script:
+          - yarn install
+            #👇Runs Chromatic with the flag to compress the build output.
+          - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --zip
+```
+
 ### UI Test and UI Review
 
 [UI Tests](test) and [UI Review](review) rely on [branch and baseline](branching-and-baselines) detection to keep track of [snapshots](snapshots). We recommend the following configuration.
@@ -82,7 +105,7 @@ pipelines:
         # Other pipeline configuration
         script:
           - yarn install
-            # 👇 Runs Chromatic with the flag to prevent pipeline failure 
+            # 👇 Runs Chromatic with the flag to prevent pipeline failure
           - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes
 ```
 
@@ -103,7 +126,6 @@ If you deny any change, you will need to make the necessary code changes to fix 
 A clean `main` branch is a development **best practice** and **highly recommended** for Chromatic. In practice, this means ensuring that test builds in your `main` branch are passing.
 
 If the builds are a result of direct commits to `main`, you will need to accept changes to keep the main branch clean. If they're merged from `feature-branches`, you will need to make sure those branches are passing _before_ you merge into `main`.
-
 
 #### BitBucket squash/rebase merge and the "main" branch
 
@@ -131,7 +153,6 @@ pipelines:
           name: 'Publish to Chromatic'
           script:
             - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN
-
 ```
 
 <div class="aside">
@@ -166,7 +187,6 @@ Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 
 Including the `--ignore-last-build-on-branch` flag ensures the latest build for the specific branch is not used as a baseline.
 
-
 #### BitBucket pipelines and patch builds
 
 If you're creating a [patch build](branching-and-baselines#patch-builds) in Chromatic to fix a missing pull request comparison, you'll need to adjust your existing pipeline to the following:
@@ -174,13 +194,12 @@ If you're creating a [patch build](branching-and-baselines#patch-builds) in Chro
 ```yml
 # bitbucket-pipelines.yml
 
-
 pipelines:
   pull-requests:
     # 👇 Will run as default for any branch not elsewhere defined
     '**':
       - step:
-           # 👇 Adds Chromatic as a step in the pipeline
+          # 👇 Adds Chromatic as a step in the pipeline
           name: 'Publish to Chromatic'
           caches:
             - node
@@ -200,7 +219,6 @@ Now you'll be able to to see the UI changeset for PRs and perform [UI Review](re
 <div class="aside">
 See the following <a href="https://community.atlassian.com/t5/Bitbucket-Pipelines-questions/pipeline-doesnt-recognize-origin-master/qaq-p/968614">BitBucket issue</a> for a detailed explanation.
 </div>
-
 
 #### Run Chromatic on external forks of open source projects
 

--- a/circleci.md
+++ b/circleci.md
@@ -21,7 +21,7 @@ jobs:
   # Other jobs
 
   # 👇 Adds Chromatic as a job
-  chromatic-deployment: 
+  chromatic-deployment:
     docker:
       - image: circleci/node:12
     working_directory: ~/repo
@@ -35,7 +35,6 @@ jobs:
         # 👇 Runs the Chromatic CLI
       - run: yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}
 
-
 workflows:
   # 👇 Adds Chromatic to the workflow
   chromatic-deploy:
@@ -46,7 +45,6 @@ workflows:
 <div class="aside">
 For extra security, add Chromatic's <code>project-token</code> as an environment variable. See the official CircleCI <a href="https://circleci.com/docs/2.0/env-vars/">environment variables documentation</a>.
 </div>
-
 
 ### Run Chromatic on specific branches
 
@@ -76,6 +74,30 @@ Read the official CircleCI <a href="https://circleci.com/docs/2.0/configuration-
 
 Now Chromatic will only run in the `main` branch.
 
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend adjusting your workflow and run the `chromatic` command with the `--zip` flag to compress your build before uploading it. For example:
+
+```yml
+# .circleci/config.yml
+
+# Other required configuration
+
+jobs:
+  # Other jobs
+
+  # 👇 Adds Chromatic as a job
+  chromatic-deployment:
+    # Other configuration
+    steps:
+      # Other job steps
+
+      #👇Runs Chromatic with the flag to compress the build output.
+      - run: yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --zip
+
+# Workflows here
+```
+
 ### External Pull Requests
 
 See this [CircleCI documentation](https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/) for workflows related to pull requests from forked repositories.
@@ -84,8 +106,7 @@ See this [CircleCI documentation](https://circleci.com/blog/triggering-trusted-c
 
 For a more complex workflow configuration, checkout this [Chromatic CircleCI Orb](https://circleci.com/orbs/registry/orb/wave/chromatic) made by a customer.
 
-In there you'll find various scenarios that you can use depending on  your needs.
-
+In there you'll find various scenarios that you can use depending on your needs.
 
 ### UI Test and UI Review
 
@@ -104,7 +125,7 @@ jobs:
   # Other jobs
 
   # 👇 Adds Chromatic as a job
-  chromatic-deployment: 
+  chromatic-deployment:
     # Other configuration
     steps:
       # Other job steps
@@ -113,7 +134,6 @@ jobs:
       - run: yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes
 
 # Workflows here
-
 ```
 
 <div class="aside">
@@ -136,7 +156,7 @@ If the builds are a result of direct commits to `main`, you will need to accept 
 
 #### Squash/rebase merge and the "main" branch
 
-We use GitHub, GitLab, and Bitbucket APIs respectively to detect squashing and rebasing so your baselines match your expectations no matter your Git workflow  (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
+We use GitHub, GitLab, and Bitbucket APIs respectively to detect squashing and rebasing so your baselines match your expectations no matter your Git workflow (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
 If you’re using this functionality but notice the incoming changes were not accepted as baselines in Chromatic, then you'll need to adjust the `chromatic` command and include the `--auto-accept-changes` flag. For example:
 
@@ -172,7 +192,7 @@ jobs:
   # Other jobs
 
   # 👇 Adds Chromatic as a job
-  chromatic-deployment: 
+  chromatic-deployment:
     # Other configuration
     steps:
       # Other job steps
@@ -181,8 +201,8 @@ jobs:
       - run: yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --ignore-last-build-on-branch=my-branch
 
 # Workflows here
-
 ```
+
 Including the `--ignore-last-build-on-branch` flag ensures the latest build for the specific branch is not used as a baseline.
 
 #### Run Chromatic on external forks of open source projects

--- a/custom-ci-provider.md
+++ b/custom-ci-provider.md
@@ -32,6 +32,17 @@ For extra security, add Chromatic's <code>project-token</code> as an environment
 
 Depending on the CI provider you're using, running Chromatic from a specific branch will not be a issue. Refer to your CI documentation for further details.
 
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend adjusting your workflow and run the `chromatic` command with the `--zip` flag to compress your build before uploading it. For example:
+
+```yml
+# your-workflow
+- run:
+    #👇Runs Chromatic with the flag to compress the build output.
+    command: npm run chromatic --project-token=CHROMATIC_PROJECT_TOKEN --zip
+```
+
 ### Overriding Chromatic's branch detection
 
 If your worflow includes a set of rules for branches (e.g., renames the branch, creates ephemeral, or temporary branches) it can lead to unforeseen build errors.
@@ -62,7 +73,7 @@ If you are using pull request statuses as required checks before merging, you ma
 
 - run:
     # 👇 Runs Chromatic with the flag to prevent stage failure
-    command: npm run chromatic --project-token=CHROMATIC_PROJECT_TOKEN
+    command: npm run chromatic --project-token=CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes
 ```
 
 <div class="aside">

--- a/github-actions.md
+++ b/github-actions.md
@@ -46,7 +46,7 @@ In a new browser window, navigate to your GitHub repository. Click the **Setting
 
 ![GitHub Secrets workflow](img/secrets-workflow-optimized.png)
 
-Fill in the form with the necessary information, as detailed below, replace `Value` with your own Chromatic project token.
+Fill in the form with the necessary information, as detailed below, and replace `Value` with your own Chromatic project token.
 
 ![GitHub repository secret configured](img/github-repo-new-secret-filled.png)
 
@@ -89,6 +89,7 @@ Chromatic's GitHub Action includes additional options to customize your workflow
 | **ignoreLastBuildOnBranch** | Ignores the latest build on the current branch as a baseline if that build. Multiple branches are allowed through [picomatch] | _String_              | my-branch         | N/A              |
 | **workingDir**              | Provide the location of Storybook's `package.json` if installed in a subdirectory (i.e., monorepos)                           | _String_              | my-folder         | N/A              |
 | **skip**                    | Skip Chromatic tests, but mark the commit as passing. Avoids blocking PRs due to required merge checks                        | _String_ or _Boolean_ | branch or true    | false            |
+| **zip**                     | Publish your Storybook to Chromatic as a single zip file instead of individual content files.                                 | _Boolean_             | true              | false            |
 
 ### Outputs
 
@@ -163,6 +164,33 @@ Read the official <a href="https://docs.github.com/en/free-pro-team@latest/actio
 Now Chromatic will run for any branch except `example`.
 
 Other branches can also be included, such as the ones created by the Renovate bot.
+
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend enabling the `zip` option in your workflow to compress your build before uploading it. For example:
+
+```yml
+# .github/workflows/chromatic.yml
+
+# Other configuration required
+
+# List of jobs
+jobs:
+  chromatic-deployment:
+    # Operating System
+    runs-on: ubuntu-latest
+    # Job steps
+    steps:
+      - uses: actions/checkout@v1
+      - run: yarn
+        #👇 Adds Chromatic as a step in the workflow
+      - uses: chromaui/action@v1
+        # Options required for Chromatic's GitHub Action
+        with:
+          projectToken: {% raw %}${{ secrets.CHROMATIC_PROJECT_TOKEN }}{% endraw %}
+          #👇Runs Chromatic with the option to compress the build output.
+          zip: true
+```
 
 ### Support for environment variables
 
@@ -289,7 +317,7 @@ If the builds result from direct commits to `main`, you will need to accept chan
 
 #### GitHub squash/rebase merge and the "main" branch
 
-GitHub's squash/rebase merge functionality creates new commits that have no association to the branch being merged. If you've enabled our GitHub application in the [UI Review](review) workflow, then we will automatically detect this situation and bring baselines over (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
+GitHub's squash/rebase merge functionality creates new commits that have no association with the branch being merged. If you've enabled our GitHub application in the [UI Review](review) workflow, then we will automatically detect this situation and bring baselines over (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
 If you’re using this functionality but notice the incoming changes were not accepted as baselines in Chromatic, then you'll need to adjust the workflow to include a new step with the `autoAcceptChanges` option. For example:
 

--- a/gitlab.md
+++ b/gitlab.md
@@ -74,6 +74,27 @@ Read the official GitLab <a href="https://docs.gitlab.com/ee/ci/yaml/#rules">con
 
 Now your pipeline will only run Chromatic in the `main` branch.
 
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend adjusting your pipeline and run the `chromatic` command with the `--zip` flag to compress your build before uploading it. For example:
+
+```yml
+# .gitlab-ci.yml
+
+# Additional pipeline configurations
+
+# Sets the stages for the pipeline
+stages:
+  - test
+
+#👇Adds Chromatic as a job
+chromatic_publish:
+  stage: test
+  #👇Runs Chromatic with the flag to compress the build output.
+  script:
+    - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --zip
+```
+
 ### UI Test and UI Review
 
 [UI Tests](test) and [UI Review](review) rely on [branch and baseline](branching-and-baselines) detection to keep track of [snapshots](snapshots). We recommend the following configuration.
@@ -96,7 +117,7 @@ chromatic_publish:
   stage: test
   #👇Runs Chromatic with the flag to prevent pipeline failure
   script:
-    - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN  --exit-zero-on-changes
+    - yarn chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes
 ```
 
 <div class="aside">

--- a/jenkins.md
+++ b/jenkins.md
@@ -34,6 +34,7 @@ pipeline {
   }
 }
 ```
+
 <div class="aside">
 For extra security, add Chromatic's <code>project-token</code> as an environment variable. See the official official Jenkins <a href="https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables"> environment variables documentation</a>.
 </div>
@@ -50,7 +51,7 @@ pipeline {
 
   stages {
     /* Other pipeline stages */
-    
+
     /* 👇 Adds Chromatic as a stage */
     stage('Publish to Chromatic') {
       when {
@@ -61,7 +62,7 @@ pipeline {
       }
       steps {
          /* 👇 Runs the Chromatic CLI */
-         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}" 
+         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}"
       }
     }
   }
@@ -73,6 +74,33 @@ Read the official Jenkins <a href="https://www.jenkins.io/doc/book/pipeline/synt
 </div>
 
 Now your pipeline will only run Chromatic in the `example` branch.
+
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend adjusting your workflow and run the `chromatic` command with the `--zip` flag to compress your build before uploading it. For example:
+
+```groovy
+/* JenkinsFile */
+
+pipeline {
+  /* Other pipeline configuration. */
+
+  stages {
+    /* Other pipeline stages */
+
+    /* 👇 Adds Chromatic as a stage */
+    stage('Publish to Chromatic') {
+      environment {
+        CHROMATIC_PROJECT_TOKEN = 'Chromatic project token'
+      }
+      steps {
+         /* 👇 Runs Chromatic with the flag to compress the build output. */
+         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --zip"
+      }
+    }
+  }
+}
+```
 
 ### Overriding Chromatic's branch detection
 
@@ -88,7 +116,7 @@ pipeline {
 
   stages {
     /* Other pipeline stages */
-    
+
     /* 👇 Adds Chromatic as a stage */
     stage('Publish to Chromatic') {
       environment {
@@ -97,7 +125,7 @@ pipeline {
       }
       steps {
          /* 👇 Runs the Chromatic CLI --branch-name flag to override the baseline branch */
-         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --branch-name=${YOUR_BRANCH}" 
+         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --branch-name=${YOUR_BRANCH}"
       }
     }
   }
@@ -170,7 +198,6 @@ If the builds are a result of direct commits to `main`, you will need to accept 
 
 #### Squash/rebase merge and the "main" branch
 
-
 We use GitHub, GitLab, and Bitbucket APIs respectively to detect squashing and rebasing so your baselines match your expectations no matter your Git workflow (see [Branching and Baselines](branching-and-baselines#squash-and-rebase-merging) for more details).
 
 If you’re using this functionality but notice the incoming changes were not accepted as baselines in Chromatic, then you'll need to adjust the pipeline and include a new Chromatic stage using the `--auto-accept-changes` flag. For example:
@@ -183,31 +210,31 @@ pipeline {
 
   stages {
     /* Other pipeline stages */
-    
+
     /* 👇 Checks if the current branch is not main and runs Chromatic */
     stage('Publish to Chromatic') {
-      when { 
-        not { 
-          branch 'main' 
-        } 
+      when {
+        not {
+          branch 'main'
+        }
       }
       environment {
         CHROMATIC_PROJECT_TOKEN = 'Chromatic project token'
       }
       steps {
-         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}" 
+         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}"
       }
     }
     /* 👇 Checks if the current branch is main and runs Chromatic with the flag to accept all changes */
     stage('Publish to Chromatic and auto accept changes') {
-      when { 
+      when {
          branch 'main'
       }
       environment {
         CHROMATIC_PROJECT_TOKEN = 'Chromatic project token'
       }
       steps {
-         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes" 
+         sh "yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes"
       }
     }
   }
@@ -251,13 +278,11 @@ Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 
 Including the `--ignore-last-build-on-branch` flag ensures the latest build for the specific branch is not used as a baseline.
 
-
 #### Run Chromatic on external forks of open source projects
 
 You can enable PR checks for external forks by sharing your `project-token` where you configured the Chromatic command (often in `package.json` or in the pipeline stage).
 
 There are tradeoffs. Sharing `project-token`'s allows _contributors_ and others to run Chromatic. They'll be able to use your snapshots. They will not be able to get access to your account, settings, or accept baselines. This can be an acceptable tradeoff for open source projects who value community contributions.
-
 
 #### Skipping builds for certain branches
 

--- a/travisci.md
+++ b/travisci.md
@@ -55,13 +55,32 @@ jobs:
 Read the official Travis CI <a href="https://docs.travis-ci.com/user/conditional-builds-stages-jobs/"> conditional build documentation</a>.
 </div>
 
+### Run Chromatic on large projects
+
+Chromatic is prepared to handle large file uploads (with a limit of 5000 files, including stories and assets). If your project exceeds this limit, we recommend adjusting your workflow and run the `chromatic` command with the `--zip` flag to compress your build before uploading it. For example:
+
+```yml
+# travis.yml
+
+# Other required configuration
+
+jobs:
+  include:
+    # Other jobs
+
+    # 👇 Adds Chromatic as a job
+    - name: 'Publish to Chromatic'
+      #👇Runs Chromatic with the flag to compress the build output.
+      script: yarn chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --zip
+```
+
 ### Recommended configuration for build events
 
 Travis CI like other CI systems offer the option of running builds for various types of events. For instance for commits pushed to a branch in a pull request. Or for "merge" commits between that branch and the base branch (main).
 
-These specific types of commits (merge) don't persist in the history of your repository. That can cause Chromatic's baselines to be lost in certain situations. 
+These specific types of commits (merge) don't persist in the history of your repository. That can cause Chromatic's baselines to be lost in certain situations.
 
-For internal pull requests (ie. pull requests that aren't from forks) we recommend disabling Chromatic on `pr` build events. Also make sure you have `push` builds enabled in your settings. 
+For internal pull requests (ie. pull requests that aren't from forks) we recommend disabling Chromatic on `pr` build events. Also make sure you have `push` builds enabled in your settings.
 
 Once these conditions are met, add the following code to your `.travis.yml`:
 
@@ -82,7 +101,6 @@ jobs:
 ```
 
 For external pull requests (i.e forked repositories), the above code will ensure Chromatic runs with the `pr` build event, because Travis will not trigger `push` events for these cases.
-
 
 ### UI Test and UI Review
 
@@ -178,7 +196,6 @@ Read our <a href="/docs/cli#chromatic-options"> CLI documentation</a>.
 Including the `--ignore-last-build-on-branch` flag ensures the latest build for the specific branch is not used as a baseline.
 
 #### Run Chromatic on external forks of open source projects
-
 
 You can enable PR checks for external forks by sharing your `project-token` where you configured the Chromatic command (often in `package.json` or in the job).
 


### PR DESCRIPTION
This pull request updates the CI documentation to include the zip option to tell our customers how they handle projects with a big amount of assets and stories.

Addresses and closes the following [linear task](https://linear.app/chromaui/issue/AP-1801/add-zip-option-to-github-actions-doc)

What was done:
- Updated every CI provider docs with text and examples on how to run Chromatic with the option.

@codykaup can you take a look and see if it's all good on your end and follow up with me?