### PR TITLE
Fix broken Storybook repo link

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -233,7 +233,7 @@ StoryWithDimensions.args = {};
 <details>
 <summary>Do you support taking snapshots of a component with multiple themes?</summary>
 
-We recommend you render stories multiple times, one for each theme. Here's [a code snippet](https://github.com/storybookjs/storybook/blob/next/examples/official-storybook/preview.js#L90-L141) of how to configure Storybook to show the same story in multiple themes. This is how the snapshots will [appear in Chromatic](https://www.chromatic.com/library?appId=5a375b97f4b14f0020b0cda3&branch=next).
+We recommend you render stories multiple times, one for each theme. Here's [a code snippet](https://github.com/storybookjs/storybook/blob/next/code/examples/official-storybook/preview.js#L108-L172) of how to configure Storybook to show the same story in multiple themes. This is how the snapshots will [appear in Chromatic](https://www.chromatic.com/library?appId=5a375b97f4b14f0020b0cda3&branch=next).
 
 If you'd only like to see multiple themes side-by-side in Chromatic and not in your local Storybook, use [isChromatic()](isChromatic).
 


### PR DESCRIPTION
Currently, there is a broken link on the `faq` page that links to the Storybook repo on GitHub
<img width="1414" alt="Screen Shot 2022-09-22 at 8 45 10 PM" src="https://user-images.githubusercontent.com/12070791/191878487-a8ed2b9e-6926-49cd-a7f5-ef7671b739f7.png">

This PR fixes the broken link reported by a customer in Intercom
https://app.intercom.com/a/inbox/zj7sn9j1/inbox/shared/mentions/conversation/27254085294?view=List

I also searched the rest of the docs pages for any other reference to the Storybook repo and there are no other instances.

### Testing
* Pull down the branch `fix-broken-link-on-faq`
* Run the docs locally
* Verify that the link on the `faq` page works correctly and does not 404
* `/docs/faq#do-you-support-taking-snapshots-of-a-component-with-multiple-the`
