### PR TITLE
Minor tweaks to access docs

### DIFF
--- a/access.md
+++ b/access.md
@@ -69,7 +69,7 @@ We recommend signing up with email for projects that **are not** on GitHub, Bitb
 
 #### Single Sign-On (SSO)
 
-Single Sign-On (SSO) is available to enterprise customers. To sign in, make sure to navigate to your team's custom Chromatic URL, for example, `mycompany.chromatic.com`.
+Single Sign-On (SSO) is available to enterprise customers. To sign-in, make sure to navigate to your team's custom Chromatic URL, for example, `mycompany.chromatic.com`.
 
 If you don't know the Chromatic URL for your team, you may need to ask the account or project owner.
 


### PR DESCRIPTION
With his small pull request the access documentation is updated to provide a bit more context on the access documentation.  Addresses [DX-320](https://linear.app/chromaui/issue/DX-320/chromatic-docs-extend-access-documentation).

@ethriel3695 can you take a pass at it and let me know of any feedback. Thanks in advance.