### PR TITLE
Fix broken links on turbosnap page

### DIFF
--- a/turbosnap.md
+++ b/turbosnap.md
@@ -284,13 +284,13 @@ If you have a large dependency tree, the build process may fail due to an out of
 <details>
   <summary>Why do merge commits test more changes than I expect?</summary>
 
-Ordinarily, TurboSnap uses git to find all files that have changed since the <a href="/branching-and-baselines#calculating-the-ancestor-builds">ancestor build</a> to determine which components/stories to snapshot. The changed file behavior is more complex with merge commits because there are two "ancestor builds".
+Ordinarily, TurboSnap uses git to find all files that have changed since the <a href="/docs/branching-and-baselines#calculating-the-ancestor-builds">ancestor build</a> to determine which components/stories to snapshot. The changed file behavior is more complex with merge commits because there are two "ancestor builds".
 
 When you have a merge commit, Chromatic considers **any file that has changed since either ancestor's commit** to decide if a story needs to be re-snapshotted. In other words, the union of the git changes.
 
 The reason for this behaviour relates to what Chromatic does when it chooses not to re-snapshot a story. In such case, it "copies" the snapshot for the story from the ancestor build, knowing (due to the git check) that the story cannot have changed in the meantime.
 
-In the case of merge commits, Chromatic does not know ahead of time which side of the merge the snapshot might be copied from because that involves running the <a href="/branching-and-baselines#calculating-a-snapshot-baseline-from-the-ancestor-builds">complete baseline selection</a> process, so it needs to be conservative and allow for changes on either branch.
+In the case of merge commits, Chromatic does not know ahead of time which side of the merge the snapshot might be copied from because that involves running the <a href="/docs/branching-and-baselines#calculating-a-snapshot-baseline-from-the-ancestor-builds">complete baseline selection</a> process, so it needs to be conservative and allow for changes on either branch.
 
 </details>
 


### PR DESCRIPTION
This fixes two broken links on the Turbosnap page, both found in the "Troubleshooting" section under the question "Why do merge commits test more changes than I expect?"