### PR TITLE
Chore: (Docs)Fix 404 link in snapshot docs

### DIFF
--- a/snapshots.md
+++ b/snapshots.md
@@ -239,7 +239,7 @@ StoryWithDimensions.args = {};
 <details>
 <summary>Do you support taking snapshots of a component with multiple themes?</summary>
 
-We recommend you render stories multiple times, one for each theme. Here's [a code snippet](https://github.com/storybookjs/storybook/blob/next/code/examples/official-storybook/preview.js#L108-L172) of how to configure Storybook to show the same story in multiple themes. This is how the snapshots will [appear in Chromatic](https://www.chromatic.com/library?appId=5a375b97f4b14f0020b0cda3&branch=next).
+We recommend you render stories multiple times, one for each theme. Here's [a code snippet](https://github.com/storybookjs/storybook/blob/main/examples/official-storybook/preview.js#L91-L144) of how to configure Storybook to show the same story in multiple themes. This is how the snapshots will [appear in Chromatic](https://www.chromatic.com/library?appId=5a375b97f4b14f0020b0cda3&branch=next).
 
 If you'd only like to see multiple themes side-by-side in Chromatic and not in your local Storybook, use [isChromatic()](isChromatic).
 


### PR DESCRIPTION
With this pull request, the snapshot documentation is updated to fix a broken link as of this week, the official Storybook was removed from the monorepo's examples.

What was done:
- Updated the link to point at the `main` branch instead of `next` as a preventive measure since we currently don't have any other example to guide our customers.

Feel free to provide feedback. Thanks in advance 