### PR TITLE
Chore: (Docs) Azure pipelines tweaks

### DIFF
--- a/azure-pipelines.md
+++ b/azure-pipelines.md
@@ -34,6 +34,9 @@ stages:
           npm_config_cache: $(Pipeline.Workspace)/.npm
         # List of steps
         steps:
+          - checkout: self
+            displayName: "Get full Git history"
+            fetchDepth: 0
           # 👇 Installs and configures Node environment
           - task: NodeTool@0
             inputs:


### PR DESCRIPTION
With this pull request, the Azure pipelines docs are updated to allow a finer integration with Chromatic.

Follows up on this [ticket](https://app.intercom.com/a/apps/zj7sn9j1/inbox/inbox/mentions/conversations/27254119795) from Intercom and closes [DX-382](https://linear.app/chromaui/issue/DX-382/chromatic-docs-azure-pipelines)

What was done:
- Update the workflow and links on how to enable Chromatic with Azure Pipelines / DevOps

For reference, [here](https://github.com/jonniebigodes/chromatic-azure-example/) is the repo used for the pull request, and [here](https://dev.azure.com/joaocontadesenvolvimento/Chromatic-Integration-V2) the Azure project. 

@ethriel3695 let me know if you're ok with this. And if by any chance you check the Azure pipeline runs, you'll see that Chromatic is throwing the famous "Failed to retrieve git information" error for some reason despite having more than 2 on the repo. 
