### PR TITLE
Chore: (Docs)CSF 3 updates

### DIFF
--- a/animations.md
+++ b/animations.md
@@ -24,12 +24,11 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.parameters = {
-  // Notifies Chromatic to pause the animations when they finish for the specific story.
-  chromatic: { pauseAnimationAtEnd: true },
+export const StoryName = {
+  parameters: {
+    // Notifies Chromatic to pause the animations when they finish for the specific story.
+    chromatic: { pauseAnimationAtEnd: true },
+  },
 };
 ```
 
@@ -38,10 +37,14 @@ You can use Storybook's [parameter](https://storybook.js.org/docs/react/writing-
 ```js
 // .storybook/preview.js
 
-export const parameters = {
-  // Notifies Chromatic to pause the animations when they finish at a global level.
-  chromatic: { pauseAnimationAtEnd: true },
+const preview = {
+  parameters: {
+    // Notifies Chromatic to pause the animations when they finish at a global level.
+    chromatic: { pauseAnimationAtEnd: true },
+  },
 };
+
+export default preview;
 ```
 
 ## JavaScript animations

--- a/cli.md
+++ b/cli.md
@@ -120,9 +120,9 @@ Some options can be configured through environment variables. You will typically
 | `CHROMATIC_POLL_INTERVAL`        | Polling interval when waiting for the build to finish (default: `1000`)                                                                      |
 | `CHROMATIC_OUTPUT_INTERVAL`      | Frequency of progress output while polling or uploading (default: `10000`)                                                                   |
 | `CHROMATIC_RETRIES`              | Number of times to retry file upload (default: `5`)                                                                                          |
-| `CHROMATIC_STORYBOOK_VERSION`    | Overrides Storybook package/version detection (e.g. `@storybook/react@6.5.0-alpha.25`)                                                       |
-| `CHROMATIC_TIMEOUT`              | Number of ms before giving up on `start-storybook` (default: `300000` (5 minutes))                                                           |
-| `STORYBOOK_BUILD_TIMEOUT`        | Number of ms before giving up on `build-storybook` (default: `600000` (10 minutes))                                                          |
+| `CHROMATIC_STORYBOOK_VERSION`    | Overrides Storybook package/version detection (e.g. `@storybook/react@7.1.0-alpha.25`)                                                       |
+| `CHROMATIC_TIMEOUT`              | Number of ms before giving up on `storybook dev` (default: `300000` (5 minutes))                                                           |
+| `STORYBOOK_BUILD_TIMEOUT`        | Number of ms before giving up on `storybook build` (default: `600000` (10 minutes))                                                          |
 | `CHROMATIC_DNS_SERVERS`          | Overrides the DNS server IP address(es) used by node-fetch, comma-separated. See [troubleshooting guide for issues](#chromatic-dns-options)  |
 | `CHROMATIC_DNS_FAILOVER_SERVERS` | Fallback DNS server IPs (default: `1.1.1.1`, `8.8.8.8` (Cloudflare, Google)). See [troubleshooting guide for issues](#chromatic-dns-options) |
 | `CI`                             | See `--ci`                                                                                                                                   |

--- a/composition.md
+++ b/composition.md
@@ -25,7 +25,7 @@ In your local Storybook, add a `refs` key to [`.storybook/main.js`](https://stor
 ```js
 // .storybook/main.js
 
-module.exports = {
+const config = {
   stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
   refs: {
     'chromatic-published-Storybook': {
@@ -36,6 +36,7 @@ module.exports = {
     },
   },
 };
+export default config;
 ```
 
 When your local Storybook starts, it will auto detect the `refs` and compose your published Storybook. You'll see both sets of stories side-by-side.

--- a/delay.md
+++ b/delay.md
@@ -31,15 +31,14 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {
-  with: 'props',
-};
-StoryName.parameters = {
-  // Sets the delay for a specific story.
-  chromatic: { delay: 300 },
+export const StoryName = {
+  args: {
+    with: 'props',
+  },
+  parameters: {
+    // Sets the delay for a specific story.
+    chromatic: { delay: 300 },
+  },
 };
 ```
 
@@ -54,7 +53,7 @@ Check for DOM elements using `getBy`, `findBy`, or `queryBy` (docs [here](https:
 ```javascript
 // MyComponent.stories.js|jsx
 
-import { within, userEvent, waitFor } from '@storybook/testing-library';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 
 import { MyComponent } from './MyComponent';
@@ -64,19 +63,18 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
+export const StoryName = {
+  play: async ({ canvasElement }) => {
+    // Assigns canvas to the component root element
+    const canvas = within(canvasElement);
 
-export const StoryName = Template.bind({});
-StoryName.play = async ({ canvasElement }) => {
-  // Assigns canvas to the component root element
-  const canvas = within(canvasElement);
-
-  //   Wait for the below assertion not throwing an error anymore (default timeout is 1000ms)
-  //👇 This is especially useful when you have an asynchronous action or component that you want to wait for
-  await waitFor(() => {
-    //👇 This assertion will pass if a DOM element with the matching id exists
-    expect(canvas.getByTestId("button")).toBeInTheDocument();
-  });
+    //   Wait for the below assertion not throwing an error anymore (default timeout is 1000ms)
+    //👇 This is especially useful when you have an asynchronous action or component that you want to wait for
+    await waitFor(() => {
+      //👇 This assertion will pass if a DOM element with the matching id exists
+      expect(canvas.getByTestId('button')).toBeInTheDocument();
+    });
+  },
 };
 ```
 
@@ -84,9 +82,15 @@ If your UI requires extra time to paint after the DOM loads, consider setting a 
 
 ```javascript
 // ...
-StoryName.play = async ({ canvasElement }) => {
-  //👇 This sets a timeout of 2s
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+export const StoryName = {
+  play: async ({ canvasElement }) => {
+    // Assigns canvas to the component root element
+    const canvas = within(canvasElement);
+
+    //👇 This sets a timeout of 2s
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  },
 };
 ```
 
@@ -108,15 +112,15 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {
-  with: 'props',
+export const StoryName = {
+  args: {
+    with: 'props',
+  },
 };
 
-export const SecondStoryName = Template.bind({});
-SecondStoryName.args = {
-  with: 'other-props',
+export const SecondStoryName = {
+  args: {
+    with: 'other-props',
+  },
 };
 ```

--- a/faq.md
+++ b/faq.md
@@ -137,13 +137,27 @@ Users with the [`owner`](collaborators#roles) role can reset or cycle project to
 Chromatic follows Storybook's [naming best practice](https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy). The last level in the hierarchy is tracked as the component name.
 
 ```js
+// Button.stories.js|jsx
+
+import { Button } from './Button';
+
 export default {
   title: 'App/Components/Button',
   component: Button,
 };
 
-export const Primary = () => <Button primary>Button</Button>;
-export const Secondary = () => <Button secondary>Button</Button>;
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/react/api/csf
+ * to learn how to use render functions.
+ */
+export const Primary = {
+  render: () => <Button primary>Button</Button>,
+};
+
+export const Secondary = {
+  render: () => <Button secondary>Button</Button>,
+};
 ```
 
 In the example above, `Button` is the component name, while `Primary` and `Secondary` are the story names respectively. If your Storybook is organized in a different way, that will affect how your components and story names appear in both Chromatic and Storybook. There's no way to configure name detection.

--- a/hoverfocus.md
+++ b/hoverfocus.md
@@ -19,8 +19,6 @@ If the hover behavior is triggered via JavaScript like tooltips or dropdowns, wr
 ```js
 // Form.stories.js|jsx
 
-import React from 'react';
-
 import { userEvent, waitFor, within } from '@storybook/testing-library';
 
 import { Form } from './LoginForm';
@@ -30,28 +28,27 @@ export default {
   title: 'Form',
 };
 
-const Template = (args) => <LoginForm {...args} />;
+export const WithHoverState = {
+  play: async ({ canvasElement }) => {
+    // Starts querying the component from its root
+    const canvas = within(canvasElement);
 
-export const WithHoverState = Template.bind({});
-WithHoverState.play = async ({ canvasElement }) => {
-  // Starts querying the component from its root
-  const canvas = within(canvasElement);
+    // Looks up the input and fills it.
+    const emailInput = canvas.getByLabelText('email', {
+      selector: 'input',
+    });
 
-  // Looks up the input and fills it.
-  const emailInput = canvas.getByLabelText('email', {
-    selector: 'input',
-  });
+    await userEvent.type(emailInput, 'Example');
 
-  await userEvent.type(emailInput, 'Example');
+    // Looks up the button and interacts with it.
+    const submitButton = canvas.getByRole('button');
+    await userEvent.click(submitButton);
 
-  // Looks up the button and interacts with it.
-  const submitButton = canvas.getByRole('button');
-  await userEvent.click(submitButton);
-
-  // Triggers the hover state
-  await waitFor(async () => {
-    await userEvent.hover(canvas.getByLabelText('Email error'));
-  });
+    // Triggers the hover state
+    await waitFor(async () => {
+      await userEvent.hover(canvas.getByLabelText('Email error'));
+    });
+  },
 };
 ```
 
@@ -90,19 +87,18 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const HoverStatewithClass = Template.bind({});
-
-HoverStatewithClass.args = {
-  ...HoverState.args,
-  className: 'hover',
+export const HoverStatewithClass = {
+  args: {
+    ...HoverState.args,
+    className: 'hover',
+  },
 };
 
-export const ActiveStatewithClass = Template.bind({});
-ActiveStatewithClass.args = {
-  ...ActiveState.args,
-  className: 'active',
+export const ActiveStatewithClass = {
+  args: {
+    ...ActiveState.args,
+    className: 'active',
+  },
 };
 ```
 
@@ -146,21 +142,19 @@ export default {
   title: 'MyComponent',
 };
 
-
-const Template = (args) => <MyComponent {...args}/>;
-
-export const HoverState = Template.bind({});
-
-HoverState.args = {
-  isHovered: true,
-  label: `I'm :hover`
+export const HoverState = {
+  args: {
+    isHovered: true,
+    label: `I'm :hover`,
+  },
 };
 
-export const ActiveState = Template.bind({});
-ActiveState.args = {
-  isActive: true,
-  label: `I'm :active`
-}:
+export const ActiveState = {
+  args: {
+    isActive: true,
+    label: `I'm :active`,
+  },
+};
 ```
 
 </details>
@@ -173,8 +167,6 @@ For atomic, functional components with CSS pseudo-classes (e.g., `hover`, `activ
 ```js
 // Button.stories.js|jsx
 
-import React from 'react';
-
 import { Button } from './Button';
 
 export default {
@@ -182,17 +174,15 @@ export default {
   title: 'Button',
 };
 
-const Template = (args) => <Button {...args} />;
-
-export const WithHoverState = Template.bind({});
-WithHoverState.args = {
-  size: 'small',
-  label: 'Button',
-};
-
-WithHoverState.parameters = {
-  // Toggles the component hover state via parameter.
-  pseudo: { hover: true },
+export const WithHoverState = {
+  args: {
+    size: 'small',
+    label: 'Button',
+  },
+  parameters: {
+    // Toggles the component hover state via parameter.
+    pseudo: { hover: true },
+  },
 };
 ```
 
@@ -205,8 +195,6 @@ To simulate how the component responds when an element is focused (i.e., through
 ```js
 // Button.stories.js|jsx
 
-import React from 'react';
-
 import { userEvent, within } from '@storybook/testing-library';
 
 import { Button } from './Button';
@@ -216,17 +204,14 @@ export default {
   title: 'Button',
 };
 
-const Template = (args) => <Button {...args} />;
+export const WithFocusState = {
+  play: async ({ canvasElement }) => {
+    // Starts querying the component from its root
+    const canvas = within(canvasElement);
 
-export const WithFocusState = Template.bind({});
-
-export const WithFocusState = Template.bind({});
-WithFocusState.play = async ({ canvasElement }) => {
-  // Starts querying the component from its root
-  const canvas = within(canvasElement);
-
-  // Looks up the button and interacts with it.
-  await canvas.getByRole('button').focus();
+    // Looks up the button and interacts with it.
+    await canvas.getByRole('button').focus();
+  },
 };
 ```
 

--- a/ignoring-elements.md
+++ b/ignoring-elements.md
@@ -34,12 +34,11 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.parameters = {
-  // disables Chromatic's snapshotting on a story level
-  chromatic: { disableSnapshot: true },
+export const StoryName = {
+  parameters: {
+    // Disables Chromatic's snapshotting on a story level
+    chromatic: { disableSnapshot: true },
+  },
 };
 ```
 
@@ -50,10 +49,14 @@ In your [`.storybook/preview.js`](https://storybook.js.org/docs/react/configure/
 ```js
 // .storybook/preview.js
 
-export const parameters = {
-  // disables snapshotting on a global level
-  chromatic: { disableSnapshot: true },
+const preview = {
+  parameters: {
+    // Disables snapshotting on a global level
+    chromatic: { disableSnapshot: true },
+  },
 };
+
+export default preview;
 ```
 
 In the component's stories you'd like to enable snapshotting:
@@ -72,10 +75,9 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {};
+export const StoryName = {
+  args: {},
+};
 ```
 
 ## Ignore DOM elements
@@ -85,8 +87,6 @@ Chromatic to ignore.
 
 ```js
 // MyComponent.js
-
-import React from 'react';
 
 export function MyComponent() {
   return (

--- a/interactions.md
+++ b/interactions.md
@@ -21,8 +21,6 @@ Add a [`play`](https://storybook.js.org/docs/react/writing-stories/play-function
 ```js
 // RangeSlider.stories.js|jsx
 
-import React from 'react';
-
 import { within, userEvent } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 
@@ -33,19 +31,18 @@ export default {
   title: 'Library/Charts/RangeSlider',
 };
 
-const Template = (args) => <RangeSlider {...args} />;
+export const InputRange = {
+  play: async ({ canvasElement }) => {
+    // Assigns canvas to the component root element
+    const canvas = within(canvasElement);
 
-export const InputRange = Template.bind({});
-InputRange.play = async ({ canvasElement }) => {
-  // Assigns canvas to the component root element
-  const canvas = within(canvasElement);
+    // 🔢 Type into input field
+    await userEvent.type(canvas.getByTestId('input-max-range'), '15');
 
-  // 🔢 Type into input field
-  await userEvent.type(canvas.getByTestId('input-max-range'), '15');
-
-  // ✅ Assert that component is responding to user behavior
-  const availableOptions = await canvas.findAllByTestId('highlighted-bar');
-  await expect(availableOptions.length).toBe(15);
+    // ✅ Assert that component is responding to user behavior
+    const availableOptions = await canvas.findAllByTestId('highlighted-bar');
+    await expect(availableOptions.length).toBe(15);
+  },
 };
 ```
 
@@ -54,19 +51,6 @@ InputRange.play = async ({ canvasElement }) => {
 Read Storybook's interaction testing [docs](https://storybook.js.org/docs/react/writing-tests/interaction-testing). Get an API cheatsheet for user events [here](https://storybook.js.org/docs/react/writing-tests/interaction-testing#api-for-user-events).
 
 </div>
-
-In Storybook, your interactions and assertions are visualized in the addon panel. Enable the playback controls to step through each interaction to confirm that it’s working as intended.
-
-```js
-// .storybook/main.js|ts
-
-module.exports = {
-  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  features: {
-    interactionsDebugger: true, // 👈 Enable playback controls
-  },
-};
-```
 
 ![Storybook passed tests](img/interaction-test-storybook-passed-test.png)
 

--- a/ischromatic.md
+++ b/ischromatic.md
@@ -35,6 +35,7 @@ This is useful when you want to change behavior of one component's stories when 
 // MyComponent.stories.js|jsx
 
 import { MyComponent } from './MyComponent';
+
 import isChromatic from 'chromatic/isChromatic';
 
 export default {
@@ -42,10 +43,9 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {
-  label: isChromatic() ? `I'm in Chromatic` : `Not in Chromatic`,
+export const StoryName = {
+  args: {
+    label: isChromatic() ? `I'm in Chromatic` : `Not in Chromatic`,
+  },
 };
 ```

--- a/monorepos.md
+++ b/monorepos.md
@@ -23,9 +23,11 @@ For example, you could write in your `.storybook/main.js`:
 ```js
 // .storybook/main.js
 
-module.exports = {
+const config = {
   stories: ["../project-1/**/*.stories.js", "../project-2/**/*.stories.js"],
 };
+
+export default config;
 ```
 
 Often teams find a single Storybook for all their development works quite well, also!

--- a/snapshots.md
+++ b/snapshots.md
@@ -203,7 +203,14 @@ export default {
   title: 'Example Story',
 };
 
-export const StoryWithDimensions = () => <MyComponent/>
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/react/api/csf
+ * to learn how to use render functions.
+ */
+export const StoryWithDimensions = {
+  render: () => <MyComponent/>
+};
 ```
 
 </details>
@@ -230,10 +237,9 @@ export default {
   title: 'Example Story',
 };
 
-const Template = (args) => <MyComponent/>;
-
-export const StoryWithDimensions = Template.bind({});
-StoryWithDimensions.args = {};
+export const StoryWithDimensions = {
+  args:{},
+};
 ```
 
 </details>

--- a/sunsetting-preserve-missing.md
+++ b/sunsetting-preserve-missing.md
@@ -29,14 +29,16 @@ The `--preserve-missing` flag is commonly used when publishing a _partial_ Story
 Most likely you will have a `.storybook/main.js` which contains something like this:
 
 ```js
+// .storybook/main.js
+
 const stories = {
-  projectA: "../projectA/**.stories.js",
-  projectB: "../projectB/**.stories.js",
+  projectA: '../projectA/**.stories.js',
+  projectB: '../projectB/**.stories.js',
   // etc
 }
 
 export default {
-  stories: stories[process.env.STORYBOOK_PROJECT] || "**/*.stories.js",
+  stories: stories[process.env.STORYBOOK_PROJECT] || '**/*.stories.js',
 }
 ```
 
@@ -45,10 +47,12 @@ In which case you'd set the `STORYBOOK_PROJECT` environment variable to control 
 For the above, you might [configure your `stories`](https://storybook.js.org/docs/react/configure/overview#with-a-configuration-object) as follows:
 
 ```js
+// .storybook/main.js
+
 export default {
   stories: [
-    { directory: "../projectA", files: "*.stories.*", titlePrefix: "Project Alpha" },
-    { directory: "../projectB", files: "*.stories.*", titlePrefix: "Project Beta" },
+    { directory: '../projectA', files: '*.stories.*', titlePrefix: 'Project Alpha'},
+    { directory: '../projectB', files: '*.stories.*', titlePrefix: 'Project Beta'},
   ],
 }
 ```

--- a/threshold.md
+++ b/threshold.md
@@ -24,15 +24,14 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {
-  with: 'props',
-};
-StoryName.parameters = {
-  // Sets the diffThreshold for 0.2 for a specific story.
-  chromatic: { diffThreshold: 0.2 },
+export const StoryName = {
+  args: {
+    with: 'props',
+  },
+  parameters: {
+    // Sets the diffThreshold for the component.
+    chromatic: { diffThreshold: 0.2 },
+  },
 };
 ```
 
@@ -56,15 +55,14 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {
-  with: 'props',
-};
-StoryName.parameters = {
-  // Detect anti-aliased pixels
-  chromatic: { diffIncludeAntiAliasing: true },
+export const StoryName = {
+  args: {
+    with: 'props',
+  },
+  parameters: {
+    // Detect anti-aliased pixels
+    chromatic: { diffIncludeAntiAliasing: true },
+  },
 };
 ```
 

--- a/viewports.md
+++ b/viewports.md
@@ -22,15 +22,14 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {
-  with: 'props',
-};
-StoryName.parameters = {
-  // Set the viewports in Chromatic at a story level.
-  chromatic: { viewports: [320, 1200] },
+export const StoryName = {
+  args: {
+    with: 'props',
+  },
+  parameters: {
+    // Set the viewports in Chromatic at a story level.
+    chromatic: { viewports: [320, 1200] },
+  },
 };
 ```
 
@@ -54,16 +53,16 @@ export default {
   title: 'MyComponent',
 };
 
-const Template = (args) => <MyComponent {...args} />;
-
-export const StoryName = Template.bind({});
-StoryName.args = {
-  with: 'props',
+export const StoryName = {
+  args: {
+    with: 'props',
+  },
 };
 
-export const SecondStoryName = (args = Template.bind({}));
-SecondStoryName.args = {
-  with: 'other-props',
+export const SecondStoryName = {
+  args: {
+    with: 'other-props',
+  },
 };
 ```
 
@@ -91,10 +90,14 @@ We don't recommend this in most cases because each viewport is treated independe
 ```js
 // .storybook/preview.js
 
-export const parameters = {
-  // Set the viewports in Chromatic globally.
-  chromatic: { viewports: [320, 1200] },
+const preview = {
+  parameters: {
+    // Set the viewports in Chromatic globally.
+    chromatic: { viewports: [320, 1200] },
+  },
 };
+
+export default preview;
 ```
 
 </details>


### PR DESCRIPTION
With this pull request the snippets and documentation is updated to reflect the changes required, for example, CSF 3, [`main.js`](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#esm-format-in-mainjs) / [`preview.js`](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#default-export-in-previewjs) types and also the [binaries](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#start-storybook--build-storybook-binaries-removed)

Adding the label "Do not merge" to prevent someone from accidentally merging this before 7.0

