### PR TITLE
Adds Node version information to Setup docs

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -57,7 +57,7 @@ yarn add --dev chromatic
 npm install --save-dev chromatic
 ```
 
-<div class="aside">Storybook 6.5 or later is required. We also guarantee support for Node 14.18.x through 16.x. Other Node releases may encounter errors. To switch between versions, we recommend using [nvm](https://github.com/nvm-sh/nvm), [n](https://github.com/tj/n), or another Node version manager.</div>
+<div class="aside">Storybook 6.5 or later is required. We also guarantee support for Node 14.18.x through Node 16.19.1. Other Node releases may encounter errors. To switch between Node versions, we recommend using <a href="https://github.com/nvm-sh/nvm">nvm</a>, <a href="https://github.com/tj/n">n</a>, or another version manager.</div>
 
 <details>
 


### PR DESCRIPTION
Adds new copy to install section of Setup page calling out Node version support.

👀 👉 [Preview deployment here](https://deploy-preview-208--chromatic-docs.netlify.app/docs/setup#install).