### PR TITLE
Adds `/figma` redirect rules

### DIFF
--- a/_site_deploy/_redirects
+++ b/_site_deploy/_redirects
@@ -1,3 +1,2 @@
 / /docs/
-/figma  /docs/figma-plugin/
 /docs/figma/ /docs/figma-plugin/


### PR DESCRIPTION
To review:

* visit [deploy preview](https://deploy-preview-218--chromatic-docs.netlify.app/docs/)
* manually navigate to `/docs/figma`
* confirm redirect to `/docs/figma-plugin`