### PR TITLE
Explain we recapture `DENIED` tests regardless of TurboSnap

### DIFF
--- a/test.md
+++ b/test.md
@@ -48,7 +48,7 @@ Chromatic detects UI changes but it's still up to you to verify if changes are i
 
 - ✅&nbsp;**Accept change**: This updates the story baseline. When a snapshot is accepted it won’t need to be re-accepted until it changes, even through git branches or merges.
 
-- ❌&nbsp;**Deny change**: This marks the change as "denied" indicating a regression and immediately fails the build. You can deny multiple changes per build.
+- ❌&nbsp;**Deny change**: This marks the change as "denied" indicating a regression and immediately fails the build. You can deny multiple changes per build. Denying a change will force a re-capture on the next build, even if [TurboSnap](turbosnap) would otherwise skip it.
 
 ![Snapshot that's unreviewed](img/snapshot-unreviewed.png)
 

--- a/turbosnap.md
+++ b/turbosnap.md
@@ -33,9 +33,9 @@ It will build and test stories that may have been affected by the Git changes si
 
 1.  Chromatic considers the Git changes between the current commit and the commit of the [ancestor build](branching-and-baselines#calculating-the-ancestor-builds).
 2.  Chromatic then uses Webpack's dependency graph to track those changes back up to the story files that depend on them.
-3.  Chromatic only tests the stories defined in those story files.
+3.  Chromatic only tests the stories defined in those story files, as well as any tests that were denied on the parent build.
 
-Stories that have not changed will not be tested (i.e., snapshotted), despite appearing in Chromatic's UI as if they were. In many cases, this will lead to much-decreased snapshot usage and faster build times.
+Stories that have not changed will not be tested (i.e., snapshotted), despite appearing in Chromatic's UI as if they were. In many cases, this will lead to much-decreased snapshot usage and faster build times. If you denied any [UI Tests](test#verify-ui-changes) on the parent build, we will always re-capture those stories even if TurboSnap would otherwise skip them. This is helpful in dealing with [inconsistent snapshots](snapshots#improve-snapshot-consistency).
 
 #### Full rebuilds
 


### PR DESCRIPTION
Shipped in https://github.com/chromaui/chromatic/pull/7319

Fixes https://linear.app/chromaui/issue/AP-3068/retest-unaccepted-changes-even-if-turbosnap-would-skip-them