### PR TITLE
Added security acknowledgement

### DIFF
--- a/security.md
+++ b/security.md
@@ -26,6 +26,10 @@ You can download and read our full responsible disclosure policy from our [secur
 
 Chromatic is grateful to the following individuals for responsibly disclosing security issues, allowing us to make Chromatic safer for everyone.
 
+#### 2023
+
+- [Ye Yint Htet](https://twitter.com/yeyinth54031769)
+
 #### 2022
 
 - [Bharat Adhikari](https://www.linkedin.com/in/bharat-adhikari-726337225)


### PR DESCRIPTION
Gave credit to a security researcher (per [request](https://app.intercom.com/a/inbox/zj7sn9j1/inbox/admin/5494525/conversation/27254272011?view=List)) for responsible disclosure of an XSS open redirect vulnerability.

See [Slack conversation](https://chromaticqa.slack.com/archives/C04BGC7NWTD/p1683575855515649) for more details.