### PR TITLE
Docs: Snaphots documentation minor tweaks

### DIFF
--- a/snapshots.md
+++ b/snapshots.md
@@ -51,7 +51,7 @@ Capture Cloud uses underlying browser APIs combined with our own set of heuristi
 <details>
 <summary>3. Take a screenshot and crop it to the dimensions of the UI</summary>
 
-Chromatic crops the screenshot to the size of your component. It determines crop dimensions by measuring the bounding box of the child node of Storybook's `#storybook-root` element if you're using Storybook 7 or higher or the `#root` element with older Storybook versions. For atomic components, cropping eliminates negative spaces around snapshots reducing the visual information you must review. For pages, Chromatic captures the full width and height of the rendered UI.
+Chromatic crops the screenshot to the size of your component. It determines crop dimensions by measuring the bounding box of the child node of Storybook's `#storybook-root` element in version 7 or higher, or the `#root` element for previous versions. For atomic components, cropping eliminates negative spaces around snapshots reducing the visual information you must review. For pages, Chromatic captures the full width and height of the rendered UI.
 
 </details>
 


### PR DESCRIPTION
With this pull request, the snapshot documentation is updated to address the following [Intercom conversation](https://app.intercom.com/a/inbox/zj7sn9j1/inbox/conversation/27254376646#part_id=comment-27254376646-21909648544) as it's a bit misleading. Additionally, a small tweak to the page's table of contents was also factored in as to prevent it from rendering incorrectly.


@elseloop, when you have a moment can you take a look and let me know of any feedback you may have? Appreciate it.