### PR TITLE
Fixing npm command in TurboSnap troubleshooting and adding yarn command

### DIFF
--- a/turbosnap.md
+++ b/turbosnap.md
@@ -257,7 +257,7 @@ Alternatively, using the `trace` utility, you can manually trace a set of files 
 
 ```shell
 # npm
-npm run build-storybook --webpack-stats-json
+npm run build-storybook -- --webpack-stats-json
 
 # yarn
 yarn build-storybook --webpack-stats-json


### PR DESCRIPTION
[Intercom chat](https://app.intercom.com/a/inbox/zj7sn9j1/inbox/admin/5762236/conversation/27254476033)
Discovered typo in the build-storybook command (was listed as `npx build-storybook`).  Fixed to reflect `npm run build-storybook` and added command for yarn as well.