### PR TITLE
Making an adjustment to include how to disable shallow clones for Git…

### DIFF
--- a/src/content/ci/gitlab.md
+++ b/src/content/ci/gitlab.md
@@ -144,7 +144,7 @@ Additional paralellization can be achieved when configuring your workflow to run
 
 ### Disable Shallow Cloning
 
-GitLab performs a shallow clone by default, which can lead to required patch builds depending on how frequently you run builds between commits.  In order to avoid this, adjust your workflow to include a `GIT_DEPTH` of `0`.  This ensures Chromatic can fetch your entire git history, without having to adjust your general `Git strategy` settings:
+GitLab performs a shallow clone by default, which can lead to required patch builds depending on how frequently you run builds between commits.  In order to avoid this, adjust your workflow to include a `GIT_DEPTH` of `0`.  This ensures Chromatic can fetch your entire git history, without having to adjust your general `Git strategy` settings within GitLab:
 
 ```yml
 # .gitlab-ci.yml


### PR DESCRIPTION
…Lab per DX-720

Intercom chat [here](https://app.intercom.com/a/inbox/zj7sn9j1/inbox/admin/5762236/conversation/27254548756).

A user brought it to our attention that we do not have documentation on how to address disabling shallow clones for GitLab, as GitLab performs a shallow clone by default.  I created [DX-720](https://linear.app/chromaui/issue/DX-720/docs-update-add-depth-to-docsgitlab) to address, and info was verified from [GitLab docs](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone).