### PR TITLE
Docs - VT addon Tweaks to the FAQ page

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -338,7 +338,7 @@ Yes. Visual tests can be run on both [linked](access#linked-projects) and [unlin
 <details>
 <summary>Can I enable TurboSnap with the addon?</summary>
 
-TurboSnap is available for the addon at an experimental stage. If you already enabled it in your configuration file (i.e., `chromatic.config.json`), running a build with the addon will automatically detect and run tests based on the configuration provided.
+TurboSnap is available for the addon at an experimental stage. If you already enabled the feature in your configuration file (i.e., `chromatic.config.json`), running a build with the addon will automatically detect and run tests based on the configuration provided.
 
 </details>
 


### PR DESCRIPTION
With this pull request the FAQ was updated to contain some items related to the visual testing addon. Some considerations, similar to other pull requests, this one will also be targeting the `next` branch per what's been discussed, and I'm aware that some of the items already exist in the vt addon page, to unblock customers, however, asides from the yarn issue the other ones should live here and we keep that page more streamlined.