### PR TITLE
maintain the original non-modes based baseline

### DIFF
--- a/src/content/modes/modes.mdx
+++ b/src/content/modes/modes.mdx
@@ -416,8 +416,6 @@ export const Base = {
 };
 ```
 
-Internally, this is easily achievable simply by naming one of your modes `1200px`, but we do not mention that anywhere in our doc.
-
 ---
 
 ### Frequently asked questions


### PR DESCRIPTION
> over the last few weeks, we’ve had at least a [couple](https://linear.app/chromaui/issue/AP-3719/allow-for-migrating-from-the-default-viewport-to-modes-without-new) [customers](https://chromaticqa.slack.com/archives/C039B71MZTP/p1697123133910319?thread_ts=1697119715.035629&cid=C039B71MZTP) who are using modes but want to maintain the original (non-modes-based) baselines. Internally, this is easily achievable simply by naming one of your modes ‘1200px’, but we do not mention that anywhere in our doc.

This new section explains how to maintain baseline while testing with modes