### PR TITLE
Removes duplicate default Astro meta content tag from head

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -7,7 +7,6 @@ const twitterUsername = "chromaui";
 ---
 
 <meta charset="UTF-8" />
-<meta name="description" content="Astro description" />
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 <title>{title} • Chromatic docs</title>


### PR DESCRIPTION
After fix:
![CleanShot 2023-11-15 at 10 35 04@2x](https://github.com/chromaui/chromatic-docs/assets/1466832/91eddd46-5ceb-4f1f-8295-84ced6cd718f)

Before fix (second `meta` tag):
![CleanShot 2023-11-15 at 10 35 27@2x](https://github.com/chromaui/chromatic-docs/assets/1466832/51316484-bb5b-49f4-999e-eb37ffc1a6fa)
