### PR TITLE
Example path to Chromatic archives corrected

### DIFF
--- a/src/content/notInNavigation/e2e-visual-tests.md
+++ b/src/content/notInNavigation/e2e-visual-tests.md
@@ -273,8 +273,8 @@ Often, when using a monorepo, developers tend to keep their e2e tests in a subdi
 
 ```json
 "scripts": {
-  "archive-storybook": "CHROMATIC_ARCHIVE_LOCATION=path/to/test-results/chromatic-archives archive-storybook -c path/to/node_modules/@chromaui/archive-storybook/config",
-  "build-archive-storybook": "CHROMATIC_ARCHIVE_LOCATION=path/to/test-results/chromatic-archives build-archive-storybook -c path/to/node_modules/@chromaui/archive-storybook/config"
+  "archive-storybook": "CHROMATIC_ARCHIVE_LOCATION=path/to/test-results archive-storybook -c path/to/node_modules/@chromaui/archive-storybook/config",
+  "build-archive-storybook": "CHROMATIC_ARCHIVE_LOCATION=path/to/test-results build-archive-storybook -c path/to/node_modules/@chromaui/archive-storybook/config"
 }
 ```
 


### PR DESCRIPTION
Corrects the example [custom path](https://www.chromatic.com/docs/e2e-visual-tests/#working-in-monorepos) to Chromatic archives to not include the `/chromatic-archives` directory in the path, as that results in the `archive-storybook` command to not be able to find the archives.

Noticed this in a customer call and was able to confirm that this change solves that problem.