### PR TITLE
Adds docs for testing print styles in Chromatic

### DIFF
--- a/src/content/configuration/media-features.md
+++ b/src/content/configuration/media-features.md
@@ -1,13 +1,20 @@
 ---
 layout: "../../layouts/Layout.astro"
-title: Media Features
+title: Media features
 description: Learn how to use media features in Chromatic Capture
 sidebar: { order: 7 }
 ---
 
-# Media Features
+# Media features
 
 CSS media features enable developers to create responsive designs and adapt layouts based on device characteristics, enhancing user experiences. With Chromatic, developers can test and refine CSS media features to ensure consistent and visually appealing designs across different devices and screen sizes.
+
+## Table of contents:
+
+- [`forced-colors`](#test-high-contrast-color-schemes)
+- [`prefers-reduced-motion`](#verify-reduced-motion-animations)
+- [`media: print`](#test-print-styles)
+- [Usage with Modes](#combine-media-features-with-modes)
 
 ## Test high-contrast color schemes
 
@@ -38,7 +45,7 @@ The `forcedColors` option supports the following values:
 
 ## Verify reduced motion animations
 
-The [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) CSS media feature enables developers to check whether the user enabled a preference for reduced motion animations. Primarily used to create a more inclusive user experience for people who may experience discomfort or nausea when viewing animations that involve rapid movement. To test it in Chromatic, add the `prefersReducedMotion` option to the `chromatic` parameter:
+The [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) CSS media feature enables developers to check whether the user enabled a preference for reduced motion animations. Primarily used to create a more inclusive user experience for people who may experience discomfort or nausea when viewing animations that involve rapid movement. To test it in Chromatic, add the `prefersReducedMotion` option to the `chromatic` parameter:
 
 ```js
 // MyComponent.stories.js|jsx
@@ -87,55 +94,18 @@ export const WithPrintStyles = {
   args: {
     //...
   },
-   // 👇 Sets media to "print" for this story
+  // 👇 Sets media to "print" for this story
   parameters: {
     chromatic: { media: "print" },
   },
 };
 ```
 
-Currently, setting the `chromatic.media` parameter using [Modes](/docs/modes/) is not supported. So, though you can define a print mode, <strong>using it in a story will not work</strong>:
+## Combine media features with Modes
 
-```js
-// .storybook/modes.js
+You can add media features to existing [Modes](/modes), but you can't define media features in the Mode itself.
 
-export const allModes = {
-  print: {
-    media: "print",
-  },
-  // {...  other modes}
-};
-
-
-// MyComponent.stories.js|jsx
-
-import { allModes } from "../.storybook/modes";
-import { MyComponent } from "./MyComponent";
-
-export default {
-  component: MyComponent,
-  title: "MyComponent",
-};
-
-export const Base = {
-  args: {
-    //...
-  },
-};
-
-export const WithPrintStyles = {
-  parameters: {
-    chromatic: {
-      // 🚨 THIS WILL NOT WORK 🚨
-      modes: {
-        print: allModes["print"],
-      },
-    },
-  },
-};
-```
-
-However, you <em>can</em> combine existing modes with the `chromatic.media` parameter. For example, if you have defined modes for German and American English locales, you can write a story combining those modes with print styles. The story would create two Chromatic snapshots, one with German locale mode and print styles, and another with American English locale mode and print styles. It might look like this:
+For example, if you have existing modes for German and American English locales, you can write a story combining those modes with `chromatic.media` parameter like so:
 
 ```js
 // .storybook/modes.js
@@ -143,15 +113,18 @@ However, you <em>can</em> combine existing modes with the `chromatic.media` para
 // Define modes
 export const allModes = {
   german: {
-    locale: "de"
+    locale: "de",
   },
   american: {
-    locale: 'en-us'
+    locale: "en-us",
   },
   // {...  other modes}
 };
+```
 
+Then apply the mode and the media feature to your stories.
 
+```js
 // MyComponent.stories.js|jsx
 
 import { allModes } from "../.storybook/modes";
@@ -186,3 +159,30 @@ export const WithPrintStyles = {
   },
 };
 ```
+
+This would create two Chromatic snapshots, one with German locale mode and print styles, and another with American English locale mode and print styles.
+
+---
+
+### Troubleshooting
+
+<details>
+<summary>Can I define a media feature in Modes?</summary>
+
+No, setting media features in [Modes](/docs/modes/) is not supported.
+
+```js
+// .storybook/modes.js
+
+export const allModes = {
+  // 🚨 THESE WILL NOT WORK 🚨
+  mode: {
+    media: "print",
+    forcedColors: "active",
+    prefersReducedMotion: "reduce",
+  },
+  // {...  other modes}
+};
+```
+
+</details>


### PR DESCRIPTION
- adds new section to `/docs/media-features`
- used info from [this Slack thread](https://chromaticqa.slack.com/archives/C04BGC7NWTD/p1698068414364609) and [this PR](https://github.com/chromaui/chromatic/pull/6678)
- I decided to explicitly call out and document the lack of Modes support, as it seems an easy assumption one might make and having `🚨 THIS WILL NOT WORK 🚨` in a code snippet seems a good deterrent 

@jmhobbs Can you please make sure this sounds accurate to you?

[A direct link to updated section.](https://deploy-preview-dan-print-b13b523--chromatic-docs.netlify.app/docs/media-features/#test-print-styles)