### PR TITLE
Update docs to include reasons why baselines may be inconsistent

### DIFF
--- a/src/content/getStarted/test.md
+++ b/src/content/getStarted/test.md
@@ -48,11 +48,11 @@ When interaction tests fail, the story will be badged with "Failed test". You wi
 
 Here are common reasons baselines can be inconsistent and how to fix them.
 
-You’re not running Chromatic builds on your base branch (e.g., `main`). Chromatic will not be able to track which baselines are associated with which commits and branches. We recommend that you always run Chromatic on your base branch to ensure reliable, consistent baselines.
+If you’re not running Chromatic builds on your base branch (e.g., `main`) then Chromatic will not be able to track which baselines are associated with which commits and branches. We recommend that you always run Chromatic on your base branch to ensure reliable, consistent baselines.
 
-You’re not auto-accepting changes on your base branch (e.g., `main`). Fix by adding the [`--auto-accept-changes`](/docs/cli/#chromatic-options) flag when running on the trunk branch to ensure all incoming changes will be accepted as baselines. This guarantees that your trunk branch is always clean and passing.
+If you’re not auto-accepting changes on your base branch (e.g., `main`) then Chromatic can't enforce that your trunk branch is clean and passing. We recommend you add the [`--auto-accept-changes`](/docs/cli/#chromatic-options) flag when running on the trunk branch to ensure all incoming changes will be accepted as baselines.
 
-You're squash and rebase-merging. Enable Chromatic's GitHub App to [auto-detect](/docs/branching-and-baselines/#how-do-baselines-get-preserved-during-squash-and-rebase-merging) squash and rebase merges which maintains your baselines.
+If you're squash and rebase-merging, Chromatic will not be able to track baselines to commits accurately because squashing removes commits from git history. We recommend you enable Chromatic's GitHub App to [auto-detect](/docs/branching-and-baselines/#how-do-baselines-get-preserved-during-squash-and-rebase-merging) squash and rebase merges which maintains your baselines.
 
 </details>
 


### PR DESCRIPTION
Add docs to highlight common reasons baselines are inconsistent:

- You’re not auto accepting changes on main or master
- You’re not running Chromatic builds on main or master.
- Rebasing and squash/merge commits.

[Linear ticket](https://linear.app/chromaui/issue/DX-319/docs-baselines-are-inconsistent)