### PR TITLE
Fix code wrap in tables when the column is narrow

### DIFF
--- a/src/styles/formatting.ts
+++ b/src/styles/formatting.ts
@@ -275,6 +275,11 @@ export const formatting = css`
       // require !important to override base styles
       color: #026fb3 !important;
     }
+
+    code {
+      word-wrap: break-word;
+      max-width: 100%;
+    }
   }
   table tr {
     border-top: 1px solid #eee;


### PR DESCRIPTION
Test by going to [this URL](https://deploy-preview-327--chromatic-docs.netlify.app/docs/e2e-visual-tests/#e2e-options) and resizing your screen.

Fixes this 
![image](https://github.com/chromaui/chromatic-docs/assets/263385/24be7a79-02ac-4d9a-984e-99a822497ef4)


https://linear.app/chromaui/issue/DX-784/docs-table-cells-overlapping-in-between-large-and-small-breakpoints