### PR TITLE
Added best practices to access doc

### DIFF
--- a/src/content/collaborate/access.md
+++ b/src/content/collaborate/access.md
@@ -60,7 +60,7 @@ Chromatic's GitHub App enables [UI Review](/docs/review) for pull requests. We n
 
 <div class="aside">
 
-What we recommend is that you create a Chromatic "bot" or IT Service Account user on your GitLab or GitHub installation. That way, if a user leaves the company or a token expires, it is straightforward for your team to validate the new token. Then you would write grant permission to that user to whatever repositories you want to link to Chromatic projects (you can grant extra permissions in the future if you later want to link other projects).
+ℹ️ We recommend teams create a Chromatic “bot” or IT Service Account user on your Git provider. You can grant write permissions to that account for the repositories you want to link to Chromatic projects. This way, tokens aren’t tied to an individual user. And if a token expires, it’s straightforward for anyone on the team to validate a new one.
 
 </div>
 


### PR DESCRIPTION
Adding best practices for Organization accounts.
I'm open to having this reworded or moved somewhere else as well.

The related conversation in Slack
https://chromaticqa.slack.com/archives/C03047TQEAH/p1702913614837759?thread_ts=1702440184.234369&cid=C03047TQEAH

TLDR;
* Our customers sometimes have issues with an expired `git` token on their account or project.
* The reason is that the user who is set as the token holder has either left the company, or isn't an active user of Chromatic and only completed the setup.
* The service account approach, provides stability for customers over the long-term for continued access, and maintaining the connection to their `git` provider.