### PR TITLE
Adds `allowedArchiveDomains` to E2E Options table

### DIFF
--- a/src/content/configuration/e2e-visual-tests.md
+++ b/src/content/configuration/e2e-visual-tests.md
@@ -353,6 +353,7 @@ These options control how the Chromatic archive fixture behaves.
 | ------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `disableAutoCapture`     | `boolean` | When `true`, will disable the capture that happens automatically at the end of a test when using the Chromatic test fixture. |
 | `resourceArchiveTimeout` | `number`  | Maximum amount of time that each test will wait for the network to be idle while archiving resources.                        |
+| `allowedArchiveDomains` | `array`  | A list of domains external to the test location that you want Chromatic to also capture assets from, e.g., <code style="display: inline;">['other-domain.com','our-cdn.com']</code>. |
 
 ### Chromatic options
 


### PR DESCRIPTION
@tevanoff, I know there are naming changes coming (are a larger page reorg), but can you please sense-check this in the meantime?

![CleanShot 2023-12-21 at 13 45 11@2x](https://github.com/chromaui/chromatic-docs/assets/1466832/ae37e1f7-52c7-49a7-bb95-00c44028ac71)
