### PR TITLE
add a redirect for /workflow to /in-development

### DIFF
--- a/_site_deploy/_redirects
+++ b/_site_deploy/_redirects
@@ -1,2 +1,3 @@
 / /docs/
 /docs/figma/ /docs/figma-plugin/
+/docs/workflow/ /docs/in-development/


### PR DESCRIPTION
Workflow document was broken into "in development" and "in pull request" so the base `/workflow` route disappeared. This PR adds a redirect from `/workflow` to `/in-development`