### PR TITLE
add a redirect for vt addon page

### DIFF
--- a/_site_deploy/_redirects
+++ b/_site_deploy/_redirects
@@ -1,3 +1,4 @@
 / /docs/
 /docs/figma/ /docs/figma-plugin/
 /docs/workflow/ /docs/in-development/
+/docs/visual-testing-addon/ /docs/visual-tests-addon/


### PR DESCRIPTION
`/docs/visual-testing-addon/` → `/docs/visual-tests-addon/`

That first link was used in customer emails