### PR TITLE
Removes unnecessary caveat for unlinked projects

### DIFF
--- a/src/content/getStarted/setup.mdx
+++ b/src/content/getStarted/setup.mdx
@@ -39,7 +39,6 @@ The Chromatic CLI provides the option to generate a JUnit XML report of your bui
 Unlinked projects have certain drawbacks:
 
 - You won't get automatic PR checks, so pull requests will not be marked with our status messages. You'll need to set this up manually via your CI provider.
-- You won't have access to our UI Review workflow, because it relies on retrieving pull requests from your Git provider.
 - Authentication and access control must be handled manually through user invites.
 
 Now continue setting up Chromatic [as usual](/docs/setup#install).


### PR DESCRIPTION
Thanks to [this callout in Slack](https://chromaticqa.slack.com/archives/C052L1DQWNM/p1705442431092219).