### PR TITLE
E2E: Cypress API change

### DIFF
--- a/src/content/configuration/cypress.mdx
+++ b/src/content/configuration/cypress.mdx
@@ -59,7 +59,7 @@ const { installPlugin } = require("chromatic-cypress");
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      installPlugin(on);
+      installPlugin(on, config);
     },
   },
 });


### PR DESCRIPTION
For E2E, we made a [small change](https://github.com/chromaui/test-archiver/pull/78) to the user-facing API for Cypress to prevent existing tests from having issues running in Electron. This PR reflects that change so customers don't get tripped up.