### PR TITLE
Clarify where config.json goes

### DIFF
--- a/src/content/configuration/cli.md
+++ b/src/content/configuration/cli.md
@@ -44,7 +44,7 @@ If you don't install `chromatic` as a dependency, `npx` will automatically downl
 
 ## Configuration
 
-Chromatic CLI can be configured through options in `./chromatic.config.json` file (recommended) in your project's root folder, or by passing CLI flags.
+Chromatic CLI can be configured through options in `./chromatic.config.json` file (recommended) placed at the root of your project folder, or by passing CLI flags.
 
 For use in CI, the only required option is the project token. Get your project token from the Chromatic website during onboarding or on your project's Manage page. Store your project token as the `CHROMATIC_PROJECT_TOKEN` environment variable or secret. The CLI automatically picks up the `CHROMATIC_PROJECT_TOKEN` environment variable so you won't have to explicitly provide it.
 


### PR DESCRIPTION
From @skitterm 
> I wasn't sure where in my codebase to put the chromatic.config.json [file](https://www.chromatic.com/docs/cli/#configuration) (my first time using it). Do we want to specify "at the project root" or something, or does it not matter where users put it?

This PR clarifies where the config file goes