### PR TITLE
Skip takes in string, not string array

### DIFF
--- a/src/content/configuration/cli.md
+++ b/src/content/configuration/cli.md
@@ -61,7 +61,7 @@ A full-featured `./chromatic.config.json` file in a CI workflow where all change
   "exitOnceUploaded": true,
   "externals": ["public/**"],
   "onlyChanged": true,
-  "skip": ["dependabot/**"]
+  "skip": "dependabot/**"
 }
 ```
 


### PR DESCRIPTION
Small update to correct the example `skip` value (the type of `skip` in the options table is correct). Using `skip` with a string array (as the example currently shows) throws an error.