### PR TITLE
Secrets capitalized

### DIFF
--- a/src/content/configuration/cypress.mdx
+++ b/src/content/configuration/cypress.mdx
@@ -112,7 +112,7 @@ Use the GitHub Action with the `cypress` flag to run a build.
   uses: chromaui/action@latest
   with:
     cypress: true
-    projectToken: ${{ secrets.chromaticProjectToken }}
+    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
 # With env vars
 
@@ -120,7 +120,7 @@ Use the GitHub Action with the `cypress` flag to run a build.
   uses: chromaui/action@latest
   with:
     cypress: true
-    projectToken: ${{ secrets.chromaticProjectToken }}
+    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
   env:
     CHROMATIC_ARCHIVE_LOCATION=./custom/dir
 ```

--- a/src/content/configuration/playwright.mdx
+++ b/src/content/configuration/playwright.mdx
@@ -126,7 +126,7 @@ Use the GitHub Action with the `playwright` flag to run a build.
   uses: chromaui/action@latest
   with:
     playwright: true
-    projectToken: ${{ secrets.chromaticProjectToken }}
+    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
 # With env vars
 
@@ -134,7 +134,7 @@ Use the GitHub Action with the `playwright` flag to run a build.
   uses: chromaui/action@latest
   with:
     playwright: true
-    projectToken: ${{ secrets.chromaticProjectToken }}
+    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
   env:
     CHROMATIC_ARCHIVE_LOCATION=./custom/dir
 ```


### PR DESCRIPTION
Changed the name of the Chromatic token secret in the CI example to `CHROMATIC_PROJECT_TOKEN`, to be consistent with the non-E2E-Chromatic CI [docs](https://www.chromatic.com/docs/github-actions/#workflow-setup).