### PR TITLE
Docs: E2E configure fix typos

### DIFF
--- a/src/content/getStarted/cypress/configure.mdx
+++ b/src/content/getStarted/cypress/configure.mdx
@@ -49,7 +49,7 @@ These options control how the Chromatic archive fixture behaves.
 
 ### Chromatic options
 
-These options control how Chromatic behaves when capturing snapshots of you pages.
+These options control how Chromatic behaves when capturing snapshots of your pages.
 
 | Option                    | Type      | Chromatic Docs                                                          |
 | ------------------------- | --------- | ----------------------------------------------------------------------- |

--- a/src/content/getStarted/playwright/configure.mdx
+++ b/src/content/getStarted/playwright/configure.mdx
@@ -83,7 +83,7 @@ These options control how the Chromatic archive fixture behaves.
 
 ## Chromatic options
 
-These options control how Chromatic behaves when capturing snapshots of you pages.
+These options control how Chromatic behaves when capturing snapshots of your pages.
 
 | Option                    | Type      | Chromatic Docs                                                          |
 | ------------------------- | --------- | ----------------------------------------------------------------------- |


### PR DESCRIPTION
Follows up on #392

With this small pull request, the configuration documentation for the E2E tests was updated to address some minor typos introduced in the mentioned pull request.

@winkerVSbecks, when you have a moment, can you check and follow up with me with any feedback you may have? Thanks in advance.
