### PR TITLE
Fix incorrect config syntax for `externals`

### DIFF
--- a/src/content/ci/github-actions.md
+++ b/src/content/ci/github-actions.md
@@ -271,6 +271,21 @@ jobs:
           externals: packages/(icons/icons|tokens/src)/**
 ```
 
+Multiple file patterns can also be provided as follows:
+
+```
+# ... other config
+
+- name: Run Chromatic
+  uses: chromaui/action@latest
+  with:
+    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+    onlyChanged: true # 👈 Required option to enable TurboSnap
+    externals: |
+      *.sass
+      public/**
+```
+
 <div class="aside">
 
 The `externals` option also accept additional glob patterns defined via [picomatch].

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -179,8 +179,8 @@ jobs:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           externals: |
-            - '*.sass'
-            - 'public/**'
+            *.sass
+            public/**
 ```
 
 > If you are using the [`staticDirs`](https://storybook.js.org/docs/react/configure/images-and-assets#serving-static-files-via-storybook-configuration) option in your main Storybook config (introduced in Storybook 6.4), you should flag those as externals as well. While the deprecated `--static-dir` (`-s`) Storybook CLI flag is auto-detected, the config option in `main.js` is not.


### PR DESCRIPTION
The current syntax does not work. The newly proposed syntax will work when this CLI fix is in place: https://github.com/chromaui/chromatic-cli/pull/951