### PR TITLE
Docs: Minor testing package updates

### DIFF
--- a/src/content/snapshot/delay.md
+++ b/src/content/snapshot/delay.md
@@ -51,12 +51,15 @@ For finer-grained control over when a snapshot is captured, use [interactions](/
 
 Check for DOM elements using `getBy`, `findBy`, or `queryBy` (docs [here](https://testing-library.com/docs/dom-testing-library/cheatsheet/#queries)).
 
-```javascript
+```js
 // MyComponent.stories.js|jsx
 
-import { userEvent, waitFor, within } from "@storybook/testing-library";
-
-import { expect } from "@storybook/jest";
+/*
+ * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
+ * import { waitFor, within } from "@storybook/testing-library";
+ * import { expect } from "@storybook/jest";
+ */
+import { expect, waitFor, within } from "@storybook/test";
 
 import { MyComponent } from "./MyComponent";
 

--- a/src/content/snapshot/hoverfocus.md
+++ b/src/content/snapshot/hoverfocus.md
@@ -20,7 +20,11 @@ If the hover behavior is triggered via JavaScript like tooltips or dropdowns, wr
 ```js
 // Form.stories.js|jsx
 
-import { userEvent, waitFor, within } from "@storybook/testing-library";
+/*
+ * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
+ * import { userEvent, waitFor, within } from "@storybook/testing-library";
+ */
+import { userEvent, waitFor, within } from "@storybook/test";
 
 import { Form } from "./LoginForm";
 


### PR DESCRIPTION
Follows up on #382

With this pull request, the rest of the documentation was updated to account for the testing package introduced with Storybook 8.0.

What was done:
- Updated the  `@storybook/testing-library` references to account for the `@storybook/test` package
- Removed unused imports in the snippets
@winkerVSbecks, when you have a moment, can you take a pass at this and let me know of any feedback you may have. Thanks in advance