### PR TITLE
Update turbosnap docs

### DIFF
--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -27,7 +27,7 @@ It will build and test stories that may have been affected by the Git changes si
 
 - Chromatic CLI [10.0+](https://www.npmjs.com/package/chromatic)
 - Storybook 6.5+
-- Webpack (experimental Vite support is avaialable for Storybook versions prior to 8, see [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap))
+- Webpack (experimental Vite support is available for Storybook versions prior to 8, see [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap))
 - Stories correctly [configured](https://storybook.js.org/docs/react/configure/overview#configure-story-loading) in Storybook's `main.js`
 - 10 successful builds on CI with at least one accepted
 - For GitHub Actions: run on `push` rather than `pull_request` ([learn more](#github-pull_request-triggers))


### PR DESCRIPTION
The team discussed updating the prerequisites for TurboSnap to Storybook version 6.5+.
Mainly to reduce the support burden on our end.
https://chromaticqa.slack.com/archives/C04BGC7NWTD/p1712957097835369?thread_ts=1712953759.485409&cid=C04BGC7NWTD