### PR TITLE
Update role for SSO to developer

### DIFF
--- a/src/content/collaborate/collaborators.md
+++ b/src/content/collaborate/collaborators.md
@@ -126,7 +126,7 @@ Open source projects are viewable to all users even if they're not listed as a c
 
 #### Roles for Single Sign-On (SSO)
 
-Chromatic syncs collaborators with your SSO provider. All collaborators are granted `owner` capabilities.
+Chromatic syncs collaborators with your SSO provider. All collaborators are granted `developer` capabilities.
 
 ### Visibility
 


### PR DESCRIPTION
This a straightforward copy change because we no longer assign `owner` permissions to SSO users.
All SSO users are now defaulted to `developer` role permissions within Chromatic.