### PR TITLE
Docs: Minor fixes to targetted snapshots

### DIFF
--- a/src/content/cypress/targeted-snapshots.md
+++ b/src/content/cypress/targeted-snapshots.md
@@ -15,16 +15,21 @@ By default, Chromatic takes a snapshot at the end of every Cypress test, whether
 ```js
 describe("My First Test", () => {
   it("Visits the Kitchen Sink", () => {
-    // 👇 navigate to target page
+    // 👇 Navigate to target page
     cy.visit("https://example.cypress.io");
 
-    // 📸 tell Chromatic to take a snapshot of the initial page state
+    // 📸 Tell Chromatic to take a snapshot of the initial page state
     cy.takeSnapshot();
 
-    // 👇 finish the test by opening the dropdown menu
+    // 👇 Finish the test by opening the dropdown menu
     cy.get(".dropdown:first-of-type > .dropdown-toggle").click();
 
-    // 📸 Chromatic automatically takes a snapshot here, at the end of the test
+    // You can call takeSnapshot multiple times if necessary.
+    // To help disambiguate, you can give the snapshot a name, 
+    // which is passed as an argument to takeSnapshot.
+    cy.takeSnapshot("After opening dropdown");
+
+    // 📸 Chromatic automatically takes a snapshot here, at the end of the test. 
   });
 });
 ```

--- a/src/content/playwright/targeted-snapshots.md
+++ b/src/content/playwright/targeted-snapshots.md
@@ -22,16 +22,16 @@ test("Can filter product", async ({ page }, testInfo) => {
   await page.locator(".menu__item:first-of-type").click();
 
   // Call takeSnapshot to take an archive "snapshot"
-  // of the page at this point in the test
+  // of the page at this point in the test.
   // 👇 Pass testInfo to takeSnapshot
   await takeSnapshot(page, testInfo);
 
-  // continue with test
+  // Continue with the test.
   await page.getByRole("link", { name: "Add to cart" }).click();
 
-  // You can call takeSnapshot multiple times, as necessary
+  // You can call takeSnapshot multiple times if necessary.
   // To help disambiguate, you can give the snapshot a name,
-  // which is passed as the second argument to takeSnapshot
+  // which is passed as the second argument to takeSnapshot.
   await takeSnapshot(page, "After adding to cart", testInfo);
 
   await expect(page).toHaveTitle(/Cart/);


### PR DESCRIPTION
With this small pull request, the targetted snapshots documentation was updated to reflect the options available based on the current state of the implementation. Closes [AP-4590](https://linear.app/chromaui/issue/AP-4590/naming-cypress-snapshots).

@winkerVSbecks, when you have a moment, can you take a a look and let me know of any feedback you may have?

Thanks in advance