### PR TITLE
Docs: Bumps Playwright images and standardizes the artifacts naming convention

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -75,7 +75,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.44.0-jammy 
+            container: mcr.microsoft.com/playwright:v1.44.1-jammy
             steps:
               - checkout: self
                 displayName: "Get Full Git History"
@@ -103,7 +103,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
                 inputs:
                   # Chromatic automatically defaults to the test-results directory. 
                   # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-                  targetPath: custom/dir
+                  targetPath: test-results
                   artifact: test-results
                   publishLocation: "pipeline"
                 condition: succeededOrFailed()
@@ -133,14 +133,14 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
                 inputs:
                   buildType: "current"
                   artifactName: "test-results"
-                  targetPath: "$(System.DefaultWorkingDirectory)/custom/dir"
+                  targetPath: "$(System.DefaultWorkingDirectory)/test-results"
               - task: CmdLine@2
                 displayName: "Run Chromatic"
                 inputs:
                   script: npx chromatic --playwright
                 env:
                   CHROMATIC_PROJECT_TOKEN: $(CHROMATIC_PROJECT_TOKEN)
-                  CHROMATIC_ARCHIVE_LOCATION: "custom/dir"
+                  CHROMATIC_ARCHIVE_LOCATION: "test-results"
     ```   
   </Fragment>
   <Fragment slot="cypress">
@@ -191,7 +191,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
                 inputs:
                   # Chromatic automatically defaults to the cypress/downloads directory. 
                   # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-                  targetPath: custom/dir
+                  targetPath: cypress/downloads
                   artifact: test-results
                   publishLocation: "pipeline"
                 condition: succeededOrFailed()
@@ -221,14 +221,14 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
                 inputs:
                   buildType: "current"
                   artifactName: "test-results"
-                  targetPath: "$(System.DefaultWorkingDirectory)/custom/dir"
+                  targetPath: "$(System.DefaultWorkingDirectory)/cypress/downloads"
               - task: CmdLine@2
                 displayName: "Run Chromatic"
                 inputs:
                   script: npx chromatic --cypress
                 env:
                   CHROMATIC_PROJECT_TOKEN: $(CHROMATIC_PROJECT_TOKEN)
-                  CHROMATIC_ARCHIVE_LOCATION: "custom/dir"
+                  CHROMATIC_ARCHIVE_LOCATION: "cypress/downloads"
     ```   
   </Fragment>
 </IntegrationSnippets>

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -61,7 +61,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.44.0-jammy
+                  image: mcr.microsoft.com/playwright:v1.44.1-jammy
                   caches:
                     - npm
                     - node
@@ -72,7 +72,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
                   artifacts:
                     # Chromatic automatically defaults to the test-results directory. 
                     # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-                    - custom/dir/**
+                    - test-results/**
               - step:
                   name: "Run Chromatic"
                   caches:
@@ -115,7 +115,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
                 artifacts:
                   # Chromatic automatically defaults to the cypress/downloads directory. 
                   # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-                  - custom/dir/**
+                  - cypress/downloads/**
               - step:
                   name: "Run Chromatic"
                   caches:

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -63,7 +63,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-jammy-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.44.0-jammy
+          - image: mcr.microsoft.com/playwright:v1.44.1-jammy
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
@@ -96,11 +96,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
           - store_artifacts:
               # Chromatic automatically defaults to the test-results directory. 
               # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-              path: ./custom/dir/
+              path: ./test-results
           - persist_to_workspace:
               root: .
               paths:
-                - custom/dir/
+                - test-results
       Chromatic:
         executor: chromatic-ui-testing
         steps:
@@ -117,7 +117,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               name: "Run Chromatic"
               command: npx chromatic --playwright
               environment:
-                CHROMATIC_ARCHIVE_LOCATION: "custom/dir/"
+                CHROMATIC_ARCHIVE_LOCATION: "test-results"
       
     workflows:
       UI_Tests:
@@ -177,11 +177,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
           - store_artifacts:
               # Chromatic automatically defaults to the cypress/downloads directory. 
               # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly.
-              path: ./custom/dir/
+              path: ./cypress/downloads
           - persist_to_workspace:
               root: .
               paths:
-                - custom/dir/
+               - cypress/downloads
       Chromatic:
         executor: chromatic-ui-testing
         steps:
@@ -198,7 +198,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               name: "Run Chromatic"
               command: npx chromatic --cypress
               environment:
-                CHROMATIC_ARCHIVE_LOCATION: "custom/dir/"
+                CHROMATIC_ARCHIVE_LOCATION: "cypress/downloads"
     
     workflows:
       UI_Tests:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -46,19 +46,19 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.44.0-jammy
+        container: mcr.microsoft.com/playwright:v1.44.1-jammy
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.
             # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly.
-            - custom/dir
+            - test-results
         command: npx playwright test
     - run:
         name: "Chromatic"
         displayName: "Run Chromatic"
         requires: [Playwright]
         environment:
-          CHROMATIC_ARCHIVE_LOCATION: "custom/dir"
+          CHROMATIC_ARCHIVE_LOCATION: "test-results"
         command: npx chromatic --playwright
     ```
 </Fragment>
@@ -81,7 +81,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
           artifacts:
             # Chromatic automatically defaults to the cypress/downloads directory.
             # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-            - custom/dir
+            - cypress/downloads
         command:
           - npm run dev &
           - npx cypress run
@@ -90,7 +90,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
         displayName: "Run Chromatic"
         requires: [Cypress]
         environment:
-          CHROMATIC_ARCHIVE_LOCATION: "custom/dir"
+          CHROMATIC_ARCHIVE_LOCATION: "cypress/downloads"
         command: npx chromatic --cypress
     ```
 </Fragment>

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -60,7 +60,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.44.0-jammy
+          image: mcr.microsoft.com/playwright:v1.44.1-jammy
         steps:
           - uses: actions/checkout@v4
             with:
@@ -81,7 +81,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               # Chromatic automatically defaults to the test-results directory. 
               # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
               name: test-results
-              path: custom/dir
+              path: ./test-results
               retention-days: 30
       chromatic:
         name: Run Chromatic
@@ -101,7 +101,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
             uses: actions/download-artifact@v4
             with:
               name: test-results
-              path: custom/dir
+              path: ./test-results
           - name: Run Chromatic
             uses: chromaui/action@latest
             with:
@@ -110,7 +110,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
               projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
             # ⚠️ Optionally configure the archive location with env vars
-            env: CHROMATIC_ARCHIVE_LOCATION=./custom/dir
+            env: CHROMATIC_ARCHIVE_LOCATION=./test-results
     ```
   </Fragment>
   <Fragment slot="cypress">
@@ -151,7 +151,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               # Chromatic automatically defaults to the cypress/downloads directory. 
               # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly.
               name: test-results
-              path: custom/dir
+              path: ./cypress/downloads
               retention-days: 30
       chromatic:
         name: Run Chromatic
@@ -172,7 +172,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
             uses: actions/download-artifact@v4
             with:
               name: test-results
-              path: custom/dir
+              path: ./cypress/downloads
           - name: Run Chromatic
             uses: chromaui/action@latest
             with:
@@ -181,7 +181,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
               projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
             # ⚠️ Optionally configure the archive location with env vars
-            env: CHROMATIC_ARCHIVE_LOCATION=./custom/dir
+            env: CHROMATIC_ARCHIVE_LOCATION=./cypress/downloads
     ```
   </Fragment>
 </IntegrationSnippets>

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -63,22 +63,22 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.44.0-jammy
+      image: mcr.microsoft.com/playwright:v1.44.1-jammy
       script:
         - npx playwright test
       allow_failure: true
       artifacts:
         when: always
         paths:
-          # Chromatic automatically defaults to the cypress/downloads directory.
+          # Chromatic automatically defaults to the test-results directory.
           # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-          - "custom/dir/"
+          - "test-results/"
         expire_in: 4 weeks
     Chromatic:
       stage: UI_Tests
       needs: [Playwright]
       variables:
-        CHROMATIC_ARCHIVE_LOCATION: "custom/dir/"
+        CHROMATIC_ARCHIVE_LOCATION: "test-results/"
       script:
         - npx chromatic --playwright
     ```
@@ -117,13 +117,13 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         paths:
           # Chromatic automatically defaults to the cypress/downloads directory.
           # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly.
-          - "custom/dir/"
+          - "cypress/downloads/"
         expire_in: 4 weeks
     Chromatic:
       stage: UI_Tests
       needs: [Cypress]
       variables:
-        CHROMATIC_ARCHIVE_LOCATION: "custom/dir/"
+        CHROMATIC_ARCHIVE_LOCATION: "cypress/downloads/"
       script:
         - npx chromatic --cypress
     ```

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -55,7 +55,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.44.0-jammy'
+               image 'mcr.microsoft.com/playwright:v1.44.1-jammy'
                reuseNode true
              }
            }
@@ -69,14 +69,14 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
                Chromatic automatically defaults to the test-results directory. 
                Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly.
               */
-               archiveArtifacts 'custom/dir/**'
+               archiveArtifacts 'test-results/**'
              }
            }
          }
          stage('Run Chromatic'){
            environment {
              CHROMATIC_PROJECT_TOKEN = credentials('chromatic-project-token')
-             CHROMATIC_ARCHIVE_LOCATION = 'custom/dir'
+             CHROMATIC_ARCHIVE_LOCATION = 'test-results'
            }
            steps {
              /* 👇 Runs the Chromatic CLI */
@@ -118,14 +118,14 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
                Chromatic automatically defaults to the cypress/downloads directory. 
                Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly.
               */
-               archiveArtifacts 'custom/dir/**'
+               archiveArtifacts 'cypress/downloads/**'
              }
            }
          }
          stage('Run Chromatic'){
            environment {
              CHROMATIC_PROJECT_TOKEN = credentials('chromatic-project-token')
-             CHROMATIC_ARCHIVE_LOCATION = 'custom/dir'
+             CHROMATIC_ARCHIVE_LOCATION = 'cypress/downloads'
            }
            steps {
              /* 👇 Runs the Chromatic CLI */

--- a/src/content/ci/travisci.mdx
+++ b/src/content/ci/travisci.mdx
@@ -80,13 +80,13 @@ To integrate Chromatic with your existing workflow, you’ll need to add the fol
               paths:
                 # Chromatic automatically defaults to the test-results directory.
                 # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-                - custom/dir/
+                - test-results
         - stage: "Chromatic"
           name: "Run Chromatic"
           workspaces:
             use: playwright
           env:
-            - CHROMATIC_ARCHIVE_LOCATION="custom/dir/"
+            - CHROMATIC_ARCHIVE_LOCATION="test-results"
           script: npx chromatic --playwright
     ```
   </Fragment>
@@ -130,13 +130,13 @@ To integrate Chromatic with your existing workflow, you’ll need to add the fol
               paths:
                 # Chromatic automatically defaults to the cypress/downloads directory.
                 # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly. 
-                - custom/dir/
+                - cypress/downloads
         - stage: "Chromatic"
           name: "Run Chromatic"
           workspaces:
             use: cypress
           env:
-            - CHROMATIC_ARCHIVE_LOCATION="custom/dir/"
+            - CHROMATIC_ARCHIVE_LOCATION="cypress/downloads"
           script: npx chromatic --cypress
     ```
   </Fragment>

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -29,7 +29,7 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.44.0-jammy
+      image: mcr.microsoft.com/playwright:v1.44.1-jammy
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,7 +101,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.44.0-jammy
+  image: mcr.microsoft.com/playwright:v1.44.1-jammy
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -129,7 +129,7 @@ version: 2.1
 executors:
   pw-jammy-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.44.0-jammy
+      - image: mcr.microsoft.com/playwright:v1.44.1-jammy
   chromatic-ui-testing:
     docker:
       - image: cimg/node:20.12.2
@@ -209,7 +209,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.44.0-jammy'
+              image 'mcr.microsoft.com/playwright:v1.44.1-jammy'
               reuseNode true
             }
           }
@@ -229,7 +229,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.44.0-jammy'
+              image 'mcr.microsoft.com/playwright:v1.44.1-jammy'
               reuseNode true
             }
           }
@@ -272,7 +272,7 @@ image: node:iron
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.44.0-jammy
+    container: mcr.microsoft.com/playwright:v1.44.1-jammy
     options:
       parallel: 2
       artifacts:


### PR DESCRIPTION
With this pull request, the Playwright images were updated to reflect the latest release and prevent issues when deploying to CI. Additionally, the custom directory used in the examples was updated to prevent misconceptions.

