### PR TITLE
FAQ - Sticky setup doesn't work

### DIFF
--- a/src/content/snapshot/position-sticky.md
+++ b/src/content/snapshot/position-sticky.md
@@ -19,3 +19,16 @@ bottom: 0;
 ```
 
 ![Position sticky snapshots](../../images/position-sticky-fixed.jpg)
+
+---
+
+### Frequently asked questions
+
+<details>
+
+  <summary> I set up `position: sticky;` with `bottom: 0;`, but it's not working. What could be the issue?
+  </summary>
+
+  The parent container's display settings might be the problem. Sticky elements can have issues if the parent uses `display: grid;`, `display: flex;`, or similar styles. Try setting `display: initial;` on the parent container to fix.
+
+</details>


### PR DESCRIPTION
The recommended setup doesn't always work due to parent container display properties.