### PR TITLE
docs/fix-automate-with-github-actions-yml-example

### DIFF
--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -144,8 +144,6 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
             with: 
               start: npm run dev
-            with: 
-              start: npm run dev
           - uses: actions/upload-artifact@v4
             with:
               # Chromatic automatically defaults to the cypress/downloads directory. 
@@ -181,7 +179,8 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
               projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
             # ⚠️ Optionally configure the archive location with env vars
-            env: CHROMATIC_ARCHIVE_LOCATION=./cypress/downloads
+            env:
+              CHROMATIC_ARCHIVE_LOCATION: ./cypress/downloads
     ```
   </Fragment>
 </IntegrationSnippets>


### PR DESCRIPTION
While setting up cypress with chromatic and GitHub actions, I noticed two mistakes in the examples mentioned in the docs.

1. in the example for the file `.github/workflows/chromatic.yml` it has two `with`statements
```
        with: 
          start: npm run dev
        with: 
          start: npm run dev
```

2. Invalid notation for this line
```
        env: CHROMATIC_ARCHIVE_LOCATION=./cypress/downloads
```

which has to be 

```
env:
    CHROMATIC_ARCHIVE_LOCATION: ./cypress/downloads
```

This PR fixes the two issues mentioned above.