### PR TITLE
Add "popover", "uptime", "outage", and "breakpoint" keywords in docs to match what users are searching for

### DIFF
--- a/src/content/modes/viewports.mdx
+++ b/src/content/modes/viewports.mdx
@@ -1,13 +1,13 @@
 ---
 layout: "../../layouts/Layout.astro"
 title: Viewports
-description: Configure Chromatic to test responsive components at various viewports
+description: Configure Chromatic to test responsive components at various viewports and breakpoints
 sidebar: { order: 2 }
 ---
 
 import { TabItem, Tabs } from "../../components/Tabs";
 
-# Viewports for responsive UIs
+# Viewports for responsive UIs with breakpoints
 
 <div class="aside" style="margin-bottom: 2rem;">
 <p>ℹ️&nbsp;&nbsp;This page documents viewports using the modes API. Learn how to <a href="/docs/modes">get started</a>.</p>

--- a/src/content/snapshot/troubleshooting-snapshots.md
+++ b/src/content/snapshot/troubleshooting-snapshots.md
@@ -166,9 +166,9 @@ export default {
 </details>
 
 <details>
-<summary>Why are components that render in a portal (tooltip, modal, menu) getting cut off?</summary>
+<summary>Why are components that render in a portal (tooltip, modal, popover, menu) getting cut off?</summary>
 
-Portals allow components to render arbitrary elements outside the parent component's initial DOM hierarchy. For example, tooltips, modals, and menus can be triggered by a nested button, but render close to the top of the DOM hierarchy using portals.
+Portals allow components to render arbitrary elements outside the parent component's initial DOM hierarchy. For example, tooltips, modals, popovers, and menus can be triggered by a nested button, but render close to the top of the DOM hierarchy using portals.
 
 However, when using Chromatic to capture snapshots of your component, it relies on the "natural" height of your component's outermost DOM element (using Storybook's `#storybook-root` element in version 7 or higher, or the `#root` element for previous versions) to determine snapshot dimensions. As portals render outside of Storybook's DOM tree, their dimensions cannot be auto-detected by Chromatic, which can lead to cut-off snapshots.
 

--- a/src/content/troubleshooting/support.md
+++ b/src/content/troubleshooting/support.md
@@ -11,4 +11,6 @@ The fastest way to get help is to search the docs and browse our [FAQ](/docs/FAQ
 
 Our team is spread across timezones for a quick turnaround time. Use our **in-app chat** to get in touch. Please provide details like version numbers, logs, and screenshots, to speed up troubleshooting.
 
+Go to our [Status page](https://status.chromatic.com/) to check uptime and get updates on outages.
+
 If your question requires more context, contact us via [email](mailto:support@chromatic.com). We recommend using email as a last resort because it can take more time to respond.


### PR DESCRIPTION
I added "popover", "uptime", "outage", and "breakpoint" keywords in docs to match what users are searching for.

[See Algolia queries without search results](https://dashboard.algolia.com/apps/I751GHI6QM/analytics/no-results/chromatic?from=2024-07-02&to=2024-07-31)

This is complementary to existing docs.