### PR TITLE
fix gh link

### DIFF
--- a/src/content/overview/ci.mdx
+++ b/src/content/overview/ci.mdx
@@ -73,7 +73,7 @@ When a build runs it will automatically add a PR status check to the current pul
 
 GitHub, Bitbucket, or GitLab projects that are [linked to a repository](/docs/access) get this feature out of the box. If you use other version control services to host your code, you can write a custom CI script to add a check for Chromatic (via your CI provider).
 
-Require checks in [GitHub](https://help.Github.com/en/Github/administering-a-repository/enabling-required-status-checks), [GitLab](https://docs.Gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit), or [Bitbucket](https://confluence.atlassian.com/bitbucket/suggest-or-require-checks-before-a-merge-856691474.html) to ensure they are completed before merging.
+Require checks in [GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#creating-a-branch-protection-rule), [GitLab](https://docs.Gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit), or [Bitbucket](https://confluence.atlassian.com/bitbucket/suggest-or-require-checks-before-a-merge-856691474.html) to ensure they are completed before merging.
 
 [Learn how to enable mandatory Chromatic PR checks »](/docs/mandatory-pr-checks)
 


### PR DESCRIPTION
This page doesn't exist anymore: https://docs.github.com/en/Github/administering-a-repository/enabling-required-status-checks

Changed to: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#creating-a-branch-protection-rule