### PR TITLE
Docs: Snapshot fix broken link

### DIFF
--- a/src/content/snapshot/snapshots.md
+++ b/src/content/snapshot/snapshots.md
@@ -75,7 +75,7 @@ Other factors that impact when a snapshot is captured include:
 
 #### Animations and videos
 
-Chromatic [proactively pauses](docs/animations) CSS animations/transitions, videos and GIFs to prevent false positives. However, Chromatic cannot disable JavaScript-driven animations, so you are responsible for [pausing them](/docs/animations/#javascript-animations).
+Chromatic [proactively pauses](/docs/animations) CSS animations/transitions, videos and GIFs to prevent false positives. However, Chromatic cannot disable JavaScript-driven animations, so you are responsible for [pausing them](/docs/animations/#javascript-animations).
 
 If not paused during testing, the snapshot will be captured mid-animation and trigger false positives.
 


### PR DESCRIPTION
With this pull request, the snapshot documentation was updated to fix the broken link reported by the link validation tooling [here](https://github.com/chromaui/chromatic-docs/commit/99d853f958712d8abfc708e3dec5c523f824438f/checks).

If you don't mind @winkerVSbecks, going to self-merge this