### PR TITLE
Docs: E2E updates Docker images

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -71,7 +71,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.46.0-jammy
+            container: mcr.microsoft.com/playwright:v1.47.0-jammy
             steps:
               - checkout: self
                 displayName: "Get Full Git History"

--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -71,7 +71,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.45.3-jammy
+            container: mcr.microsoft.com/playwright:v1.46.0-jammy
             steps:
               - checkout: self
                 displayName: "Get Full Git History"
@@ -153,7 +153,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Cypress
             displayName: "Run Cypress"
-            container: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
+            container: cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1
             variables:
               npm_config_cache: $(Pipeline.Workspace)/.npm
             steps:

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -57,7 +57,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.45.3-jammy
+                  image: mcr.microsoft.com/playwright:v1.46.0-jammy
                   caches:
                     - npm
                     - node
@@ -96,7 +96,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - step:
                 name: "Cypress"
                 # Configure the ELECTRON_EXTRA_LAUNCH_ARGS environment variable in your project settings to run Cypress tests with Chromatic.
-                image: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
+                image: cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1
                 caches:
                   - npm
                   - node

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -57,7 +57,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.46.0-jammy
+                  image: mcr.microsoft.com/playwright:v1.47.0-jammy
                   caches:
                     - npm
                     - node

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-jammy-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.45.3-jammy
+          - image: mcr.microsoft.com/playwright:v1.46.0-jammy
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
@@ -131,7 +131,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       cypress:
         docker:
-          - image: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
+          - image: cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-jammy-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.46.0-jammy
+          - image: mcr.microsoft.com/playwright:v1.47.0-jammy
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -42,7 +42,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.45.3-jammy
+        container: mcr.microsoft.com/playwright:v1.46.0-jammy
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.
@@ -68,7 +68,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Cypress"
         displayName: "Run Cypress tests"
-        container: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
+        container: cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1
         environment:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         options:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -42,7 +42,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.46.0-jammy
+        container: mcr.microsoft.com/playwright:v1.47.0-jammy
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -56,7 +56,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.46.0-jammy
+          image: mcr.microsoft.com/playwright:v1.47.0-jammy
         steps:
           - uses: actions/checkout@v4
             with:

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -56,7 +56,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.45.3-jammy
+          image: mcr.microsoft.com/playwright:v1.46.0-jammy
         steps:
           - uses: actions/checkout@v4
             with:
@@ -120,7 +120,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         name: Run Cypress
         runs-on: ubuntu-latest
         container:
-          image: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
+          image: cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1
           options: --user 1001
         steps:
           - uses: actions/checkout@v4

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.46.0-jammy
+      image: mcr.microsoft.com/playwright:v1.47.0-jammy
       script:
         - npx playwright test
       allow_failure: true

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.45.3-jammy
+      image: mcr.microsoft.com/playwright:v1.46.0-jammy
       script:
         - npx playwright test
       allow_failure: true
@@ -99,7 +99,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Cypress:
       stage: UI_Tests
       needs: []
-      image: cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1
+      image: cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1
       variables:
         ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
       script:

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -51,7 +51,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.45.3-jammy'
+               image 'mcr.microsoft.com/playwright:v1.46.0-jammy'
                reuseNode true
              }
            }
@@ -94,7 +94,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Cypress') {
            agent {
              docker {
-               image 'cypress/browsers:node-20.15.1-chrome-126.0.6478.126-1-ff-128.0-edge-126.0.2592.102-1'
+               image 'cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1'
                reuseNode true
              }
            }

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -51,7 +51,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.46.0-jammy'
+               image 'mcr.microsoft.com/playwright:v1.47.0-jammy'
                reuseNode true
              }
            }

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -27,7 +27,7 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.45.3-jammy
+      image: mcr.microsoft.com/playwright:v1.46.0-jammy
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,7 +97,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.45.3-jammy
+  image: mcr.microsoft.com/playwright:v1.46.0-jammy
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -123,7 +123,7 @@ version: 2.1
 executors:
   pw-jammy-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.45.3-jammy
+      - image: mcr.microsoft.com/playwright:v1.46.0-jammy
   chromatic-ui-testing:
     docker:
       - image: cimg/node:20.12.2
@@ -203,7 +203,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.45.3-jammy'
+              image 'mcr.microsoft.com/playwright:v1.46.0-jammy'
               reuseNode true
             }
           }
@@ -223,7 +223,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.45.3-jammy'
+              image 'mcr.microsoft.com/playwright:v1.46.0-jammy'
               reuseNode true
             }
           }
@@ -264,7 +264,7 @@ image: node:iron
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.45.3-jammy
+    container: mcr.microsoft.com/playwright:v1.46.0-jammy
     options:
       parallel: 2
       artifacts:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -27,7 +27,7 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.46.0-jammy
+      image: mcr.microsoft.com/playwright:v1.47.0-jammy
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,7 +97,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.46.0-jammy
+  image: mcr.microsoft.com/playwright:v1.47.0-jammy
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -123,7 +123,7 @@ version: 2.1
 executors:
   pw-jammy-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.46.0-jammy
+      - image: mcr.microsoft.com/playwright:v1.47.0-jammy
   chromatic-ui-testing:
     docker:
       - image: cimg/node:20.12.2
@@ -203,7 +203,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.46.0-jammy'
+              image 'mcr.microsoft.com/playwright:v1.47.0-jammy'
               reuseNode true
             }
           }
@@ -223,7 +223,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.46.0-jammy'
+              image 'mcr.microsoft.com/playwright:v1.47.0-jammy'
               reuseNode true
             }
           }
@@ -264,7 +264,7 @@ image: node:iron
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.46.0-jammy
+    container: mcr.microsoft.com/playwright:v1.47.0-jammy
     options:
       parallel: 2
       artifacts:


### PR DESCRIPTION
With this pull request, the Docker images referenced throughout the documentation were updated to include the latest stable versions of the supported integrations (i.e., Playwright, Cypress).

What was done:
- Adjusted the examples to include the Docker images


@winkerVSbecks, when you have a moment, can you take a look and let me know if you have any feedback? Thanks in advance