### PR TITLE
Chore: Bumps Playwright versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "framer-motion": "^11.0.5",
     "github-slugger": "^2.0.0",
     "hast-util-select": "^6.0.2",
-    "playwright-core": "^1.46.0",
+    "playwright-core": "^1.47.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-lite-youtube-embed": "^2.3.52",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       playwright-core:
-        specifier: ^1.46.0
-        version: 1.46.0
+        specifier: ^1.47.0
+        version: 1.47.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -5235,8 +5235,8 @@ packages:
   pkg-types@1.1.3:
     resolution: {integrity: sha512-+JrgthZG6m3ckicaOB74TwQ+tBWsFl3qVQg7mN8ulwSOElJ7gBhKzj2VkCPnZ4NlF6kEquYU+RIYNVAvzd54UA==}
 
-  playwright-core@1.46.0:
-    resolution: {integrity: sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==}
+  playwright-core@1.47.0:
+    resolution: {integrity: sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -11902,7 +11902,7 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-free': 6.5.2
       mermaid: 10.9.1
-      playwright-core: 1.46.0
+      playwright-core: 1.47.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12641,7 +12641,7 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
 
-  playwright-core@1.46.0: {}
+  playwright-core@1.47.0: {}
 
   polished@4.3.1:
     dependencies:


### PR DESCRIPTION
With this pull request, the Playwright version used in the documentation site is updated for the latest stable version to prevent issues with the deployment.

cc @winkerVSbecks 