### PR TITLE
Docs: Adjust FAQ entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can insert Mermaid diagrams in markdown & MDX files to visualize Git commits
 
 ### Adding an FAQ item
 
-All faqs are in `src/content/faq`. Each FAQ item is a markdown file with frontmatter. The frontmatter is slightly different to other pages. You need to specify which `section` the item belongs to and optionally what order it appears in the section list (`sectionOrder`).
+All faqs are in `src/content/troubleshooting/faq` directory. Each FAQ item is a markdown file with frontmatter. The frontmatter is slightly different to other pages. You need to specify which `section` the item belongs to and optionally what order it appears in the section list (`sectionOrder`).
 
 To add an FAQ item to an existing section, create a new `.md` or `.mdx` file. It'll automatically get added to the FAQ index page.
 

--- a/src/content/storybook/setup.mdx
+++ b/src/content/storybook/setup.mdx
@@ -378,10 +378,3 @@ If styles are not rendering correctly, there could be several reasons behind tha
 If you have additional questions, use our **in-app chat** to contact or email us at [support@chromatic.com](mailto:support@chromatic.com).
 
 </details>
-
-<details>
-<summary>What is my build failing with component errors?</summary>
-
-When a story fails to render it will be badged with “Component Error”. You will not be able to “pass” a build that has component errors. Fix story errors in Storybook and run the build again.
-
-</details>

--- a/src/content/troubleshooting/faq/build-fails-component-errors.md
+++ b/src/content/troubleshooting/faq/build-fails-component-errors.md
@@ -1,0 +1,12 @@
+---
+layout: "../../../layouts/FAQLayout.astro"
+sidebar: { hide: true }
+title: Why is my build failing with component errors?
+section: "uiTestsAndReview"
+---
+
+# Why is my build failing with component errors?
+
+When a test fails to render, the associated build will be badged with a "Component error" label. This means that Chromatic cannot render one or more components, which will prevent you from accepting the changes and passing the build. We recommend fixing the associated errors and re-running the build to ensure your tests pass. If you need guidance on fixing the errors, please refer to our [troubleshooting snapshots guide](/docs/troubleshooting-snapshots).
+
+If you're still having trouble, contact us via our in-app chat or email us at support@chromatic.com.


### PR DESCRIPTION
Addresses [AP-4962](https://linear.app/chromaui/issue/AP-4962/incorrect-link-in-re-run-screen).

With this pull request, the documentation was updated to include a fully dedicated FAQ entry that enables customers to understand why their build errors with the component errors and include some information on what they could do to help solve said issues. This was prompted by my current work on fixing the links, during which I noticed that E2E users who run into this scenario are being redirected to a Storybook-centric page when that should be different. 

What was done:
- Fixed the Readme for accuracy on the FAQ entry locations
- Removed the build errors troubleshooting item
- Created a dedicated FAQ entry and polished the documentation a bit to make it more agnostic.


@winkerVSbecks when you can, can you take a look at this pull request and let me know of any feedback you may have. Thanks in advance