### PR TITLE
Add a page for TurboSnap dependency tracing

### DIFF
--- a/src/content/account/billing.md
+++ b/src/content/account/billing.md
@@ -146,7 +146,7 @@ Number of snapshots identified by [TurboSnap](#snapshots-with-turbosnap-enabled-
   <dt>TurboSnaps Bail Reason</dt>
   <dd>
 
-Explains why a TurboSnap triggered a full rebuild. For more details, check out the [TurboSnap docs](/docs/turbosnap/#full-rebuilds).
+Explains why a TurboSnap triggered a full rebuild. For more details, check out the [TurboSnap docs](/docs/turbosnap/troubleshooting#what-do-the-turbosnap-bail-reasons-in-my-usage-report-mean).
 
   </dd>
 

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -139,7 +139,7 @@ For projects using Storybook versions prior to 8, use the [vite-plugin-turbosnap
 
 Vite is natively supported for Storybook 8 and later. To generate the stats file, use the `--stats-json` flag with the `build-storybook` command.
 
-```json
+```json title="package.json"
 {
   "scripts": {
     "build-storybook": "build-storybook --stats-json"
@@ -151,7 +151,7 @@ Vite is natively supported for Storybook 8 and later. To generate the stats file
 
 If you're using a prebuilt Storybook, and your `build-storybook` script was not executed from the same directory where you're running `chromatic`, you'll have to specify the relative path to the Storybook project root (where you run `build-storybook` from). For example, when your Storybook lives at `./services/webapp` in your Git repository:
 
-```json
+```json title="package.json"
 {
   "scripts": {
     // This would be a different package.json than the one with `build-storybook`
@@ -246,7 +246,7 @@ When configuring TurboSnap in a monorepo, it's important to ensure that Chromati
 
 Chromatic's suggested best practice when executing from your repo root is to set your `--storybook-base-dir` and `--storybook-config-dir` flags. For example, when your Storybook project is located in the `packages/webapp` dir of your repo, you'd update your script to reflect the following:
 
-```json
+```json title="package.json"
 {
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -28,7 +28,7 @@ It will build and test stories that may have been affected by the Git changes si
 
 - Chromatic CLI [10.0+](https://www.npmjs.com/package/chromatic)
 - Storybook 6.5+
-- Webpack (experimental Vite support is available for Storybook versions prior to 8, see [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap))
+- Webpack or Vite based project (Vite is natively supported with Storybook 8+ and can be used in earlier versions with the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap))
 - Stories correctly [configured](https://storybook.js.org/docs/configure#configure-story-loading) in Storybook's `main.js`
 - 10 successful builds on CI with at least one accepted
 - For GitHub Actions: run on `push` rather than `pull_request` ([learn more](#github-pull_request-triggers))
@@ -66,11 +66,7 @@ You may need additional config in the following situations:
 - You have files that should never trigger a re-test (e.g., in a monorepo)
 - You want to enable or disable TurboSnap for specific branches
 
-<div class="aside">
-
-ℹ️ You can verify your glob pattern using the [picomatch-playground](https://picomatch-playground-ebjlxm.csb.app/).
-
-</div>
+Jump to the [recipes](#recipes) section for more information.
 
 ### Verify that TurboSnap is working
 
@@ -115,9 +111,9 @@ Once TurboSnap is activated, all subsequent builds will display an indicator wit
 
 A few common scenarios require additional configuration.
 
-### TurboSnap with prebuilt Storybook
+### TurboSnap with prebuilt Storybook using Webpack
 
-If you're using `--storybook-build-dir` to provide a prebuilt Storybook, adjust your `build-storybook` script to include the `--stats-json` option (or `--webpack-stats-json` option for Storybook projects that haven't migrated to Storybook 8+). If Chromatic builds your Storybook for you, this is unnecessary, and will take care of it. For example:
+If you're using `--storybook-build-dir` to provide a prebuilt Storybook, adjust your `build-storybook` script to include the `--stats-json` option (or `--webpack-stats-json` option for projects that haven't migrated to Storybook 8+). If Chromatic builds your Storybook for you, this is unnecessary, and will take care of it. For example:
 
 ```json
 {
@@ -137,7 +133,21 @@ You must pass `webpackStatsJson` as a [prop to options](https://nx.dev/nx-api/st
 
 </details>
 
-#### Specify a deviating Storybook base directory
+### TurboSnap with prebuilt Storybook using Vite
+
+For projects using Storybook versions prior to 8, use the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap). The plugin will automatically generate a stats file when you run the `build-storybook` command.
+
+For Storybook 8 and later, Vite is natively supported. Use the `--stats-json` flag with the `build-storybook` command to generate the stats file.
+
+```json
+{
+  "scripts": {
+    "build-storybook": "build-storybook --stats-json"
+  }
+}
+```
+
+### Specify a deviating Storybook base directory
 
 If you're using a prebuilt Storybook, and your `build-storybook` script was not executed from the same directory where you're running `chromatic`, you'll have to specify the relative path to the Storybook project root (where you run `build-storybook` from). For example, when your Storybook lives at `./services/webapp` in your Git repository:
 
@@ -192,7 +202,11 @@ jobs:
             public/**
 ```
 
-> If you are using the [`staticDirs`](https://storybook.js.org/docs/configure/integration/images-and-assets#serving-static-files-via-storybook-configuration) option in your main Storybook config (introduced in Storybook 6.4), you should flag those as externals as well. While the deprecated `--static-dir` (`-s`) Storybook CLI flag is auto-detected, the config option in `main.js` is not.
+#### Add `staticDirs` to external files
+
+If you are using the [`staticDirs`](https://storybook.js.org/docs/configure/integration/images-and-assets#serving-static-files-via-storybook-configuration) option in your main Storybook config (introduced in Storybook 6.4), you should flag those as externals as well.
+
+Whereas, the deprecated `--static-dir` (`-s`) Storybook CLI flag is auto-detected, the config option in `main.js` is not.
 
 ### Avoid re-testing dependent stories when certain files changed
 

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -137,7 +137,7 @@ You must pass `webpackStatsJson` as a [prop to options](https://nx.dev/nx-api/st
 
 For projects using Storybook versions prior to 8, use the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap). The plugin will automatically generate a stats file when you run the `build-storybook` command.
 
-For Storybook 8 and later, Vite is natively supported. Use the `--stats-json` flag with the `build-storybook` command to generate the stats file.
+Vite is natively supported for Storybook 8 and later. To generate the stats file, use the `--stats-json` flag with the `build-storybook` command.
 
 ```json
 {

--- a/src/content/turbosnap/troubleshooting-turbosnap.mdx
+++ b/src/content/turbosnap/troubleshooting-turbosnap.mdx
@@ -132,9 +132,7 @@ TurboSnap is compatible with squash and merge rebasing as of version 6.6+. Pleas
 
 ## What do the TurboSnap bail reasons in my usage report mean?
 
-The [usage report](/docs/billing/#usage-reports) can help you faster identify opportunities to improve your TurboSnap configuration. However, the bail reasons may not be clear when trying to understand what's causing the issue or which next steps you should take to help mitigate the bails.
-
-You can hover over the TurboSnap tooltip on your builds to find out more specific information, but below is an at-a-glance breakdown of the bail reasons to reference when analyzing your usage report.
+Your [usage data (CSV report)](/docs/billing/#export-usage-data-as-a-csv) can help you faster identify opportunities to improve your TurboSnap configuration. The "TurboSnaps Bail Reason" column tells you what caused TurboSnap triggered a full rebuild. Here's what each reason means:
 
 ### `changedExternalFiles`
 

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -24,7 +24,7 @@ TurboSnap leverages [Webpack's Stats Data API](https://webpack.js.org/api/stats)
 
 If Chromatic builds your Storybook, it will automatically generate the stats file. But if you provide Chromatic with a prebuilt Storybook, you must add the `--stats-json` (or `--webpack` for Storybook versions 7 and lower) flag to the `build-storybook` command.
 
-The stats file can be a bit challenging to read. Therefore, the Chromatic CLI offers a `trim-stats-file` option to make the file more human-readable. Use it like so:
+The stats file can be a bit challenging to read. Therefore, the Chromatic CLI offers a [`trim-stats-file`](/docs/configure/) option to make the file more human-readable. Use it like so:
 
 ```shell
 npx chromatic trim-stats-file

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -40,7 +40,7 @@ npx chromatic trim-stats-file ./path/to/preview-stats.json
 
 After running the `trim-stats-file` command, Chromatic will output a `preview-stats.trimmed.json` file. While this file is more readable, it can still be a bit daunting, so let's break it down with an example.
 
-```json
+```json title="preview-stats.trimmed"
 {
   "id": "./src/inputs/PinInput/PinInput.tsx",
   "name": "./src/inputs/PinInput/PinInput.tsx + 4 modules",
@@ -79,7 +79,7 @@ The `"reasons"` key provides information about the asset's dependency graph. In 
 
 The asset object for a story file usually looks a bit different:
 
-```json
+```json title="preview-stats.trimmed"
 {
   "id": "./src/inputs/PinInput/stories/PinInput.stories.tsx",
   "name": "./src/inputs/PinInput/stories/PinInput.stories.tsx + 4 modules",

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -128,8 +128,6 @@ If you're trying to understand why a story file is being detected as changed, yo
 
 ## Tracing dependencies with Vite
 
-Before Storybook 8, Vite support for TurboSnap was available through the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap). Starting with version 8.0, this plugin has been integrated into Storybook, so TurboSnap now supports Vite natively.
+Vite support for TurboSnap is available out of the box, starting with Storybook 8.0 and later, and does not require any additional configuration. However, if you're using an older version of Storybook, you must install the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap) plugin to enable TurboSnap support with Vite. 
 
-With Storybook 8.0+, if Chromatic builds your Storybook for you, it will generate the stats file for you. But if you provide a prebuilt Storybook to Chromatic then you'll need add `--stats-json` to the `build-storybook` command.
-
-Whether using the plugin or Storybook 8.0+, the process is the same. When you run the `build-storybook` command, a `preview-stats.json` file is generated. This file collects information about each module being built and creates a mapping between each file and all the files that import it. It mimics the file created by Webpack but includes only the information that TurboSnap needs to perform dependency checks.
+Similar to Webpack, when you run the `build-storybook` command, the `preview-stats.json` file is automatically generated. It contains information about each module being built and a mapping between each file and all the imported files. This structure mirrors that used by Wepack but only includes the information TurboSnap needs to perform dependency checks. 

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -106,8 +106,6 @@ The asset object for a story file usually looks a bit different:
 }
 ```
 
-Under `reasons`, you'll see a `moduleName` that looks like a path pattern. If you were to look at the non-trimmed file, you'd see the `issuerPath`'s are `"./storybook-config-entry.js"` and `"./storybook-stories.js"` because the dependency is the project's Storybook config:
-
 Under "reasons," you'll notice a `moduleName` resembling a path pattern. In the full, untrimmed file, the `issuerPath`'s are `"./storybook-config-entry.js"` and `"./storybook-stories.js"`. That's because the dependency is related to this project's Storybook configuration:
 
 ```js title=".storybook/main.js"

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -22,7 +22,7 @@ To start, let's visit [Webpack's dependency graph concept](https://webpack.js.or
 
 TurboSnap leverages [Webpack's Stats Data API](https://webpack.js.org/api/stats) to generate a JSON file with detailed statistics about a project's modules. These statistics allow TurboSnap to analyze a project's dependency graph by providing information on asset objects, related chunks (or grouped modules), and module dependencies linked to the assets.
 
-If Chromatic builds your Storybook for you, it will generate the stats file for you. But if you provide a prebuilt Storybook to Chromatic then you'll need add `--stats-json` (or `--webpack-stats-json` for Storybook versions 7 and lower) to the `build-storybook` command.
+If Chromatic builds your Storybook, it will automatically generate the stats file. But if you provide Chromatic with a prebuilt Storybook, you must add the `--stats-json` (or `--webpack` for Storybook versions 7 and lower) flag to the `build-storybook` command.
 
 The stats file can be a bit challenging to read. Therefore, the Chromatic CLI offers a `trim-stats-file` option to make the file more human-readable. Use it like so:
 

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -22,15 +22,7 @@ To start, let's visit [Webpack's dependency graph concept](https://webpack.js.or
 
 TurboSnap leverages [Webpack's Stats Data API](https://webpack.js.org/api/stats) to generate a JSON file with detailed statistics about a project's modules. These statistics allow TurboSnap to analyze a project's dependency graph by providing information on asset objects, related chunks (or grouped modules), and module dependencies linked to the assets.
 
-The stats file is generated when you add `--stats-json` (or `--webpack-stats-json` for Storybook versions 7 and lower) to the `build-storybook` command. For example:
-
-```json
-{
-  "scripts": {
-    "build-storybook": "build-storybook --stats-json"
-  }
-}
-```
+If Chromatic builds your Storybook for you, it will generate the stats file for you. But if you provide a prebuilt Storybook to Chromatic then you'll need add `--stats-json` (or `--webpack-stats-json` for Storybook versions 7 and lower) to the `build-storybook` command.
 
 The stats file can be a bit challenging to read. Therefore, the Chromatic CLI offers a `trim-stats-file` option to make the file more human-readable. Use it like so:
 
@@ -140,14 +132,6 @@ If you're trying to understand why a story file is being detected as changed, yo
 
 Before Storybook 8, Vite support for TurboSnap was available through the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap). Starting with version 8.0, this plugin has been integrated into Storybook, so TurboSnap now supports Vite natively.
 
-With Storybook 8.0+, you can can generate a stats file for Vite based projects by adding `--stats-json` to the `build-storybook` command:
-
-```json
-{
-  "scripts": {
-    "build-storybook": "build-storybook --stats-json"
-  }
-}
-```
+With Storybook 8.0+, if Chromatic builds your Storybook for you, it will generate the stats file for you. But if you provide a prebuilt Storybook to Chromatic then you'll need add `--stats-json` to the `build-storybook` command.
 
 Whether using the plugin or Storybook 8.0+, the process is the same. When you run the `build-storybook` command, a `preview-stats.json` file is generated. This file collects information about each module being built and creates a mapping between each file and all the files that import it. It mimics the file created by Webpack but includes only the information that TurboSnap needs to perform dependency checks.

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -6,100 +6,148 @@ sidebar: { order: 4, label: "Dependency Tracing" }
 slug: "turbosnap/dependency-tracing"
 ---
 
-# TurboSnap Dependency Tracing
-TurboSnap analyzes both a project's git history and Webpack's dependency graph to identify which stories have been potentially impacted by changes.  But what is Webpack's dependency graph and how does TurboSnap use it to trace dependency changes?  How does this work for projects built with Vite?  This overview will answer these questions and help you better understand dependency tracing for TurboSnap.
+# TurboSnap dependency tracing
+
+TurboSnap examines your project's Git history and Webpack's dependency graph to determine which stories might be affected by changes. If you're new to these concepts, then this guide is for you.
+
+It'll help you better understand dependency tracing, enabling you to use TurboSnap more effectively. You'll also learn how to trace dependencies in projects using Vite.
 
 ## Tracing dependencies with Webpack
+
 To start, let's visit [Webpack's dependency graph concept](https://webpack.js.org/concepts/dependency-graph/):
 
 > ❝ Any time one file depends on another, webpack treats this as a dependency. This allows webpack to take non-code assets, such as images or web fonts, and also provide them as dependencies for your application.
-> 
+>
 > When webpack processes your application, it starts from a list of modules defined on the command line or in its configuration file. Starting from these [entry points](https://webpack.js.org/concepts/entry-points/), webpack recursively builds a dependency graph that includes every module your application needs, then bundles all of those modules into a small number of bundles - often, only one - to be loaded by the browser. ❞
 
-TurboSnap uses [Webpack's Stats Data API](https://webpack.js.org/api/stats) to generate a JSON file containing statistics about the modules for a project. These statistics are how TurboSnap analyzes a project's dependency graph, as it gives the details about the asset objects, any related chunks (or grouped modules), and the module dependencies that rely on the asset.
+TurboSnap leverages [Webpack's Stats Data API](https://webpack.js.org/api/stats) to generate a JSON file with detailed statistics about a project's modules. These statistics allow TurboSnap to analyze a project's dependency graph by providing information on asset objects, related chunks (or grouped modules), and module dependencies linked to the assets.
 
-This file is generated when a customer adds `--stats-json` (or `--webpack-stats-json` for SB versions < v8). Chromatic has an option called `trim-stats-file` that can be used to make the file more human-readable, since it can be a bit confusing to read through. Here's an example of the command used to run it, but a customer can add a path at the end if they want the stats file to built to a custom directory:
+The stats file is generated when you add `--stats-json` (or `--webpack-stats-json` for Storybook versions 7 and lower) to the `build-storybook` command. For example:
+
+```json
+{
+  "scripts": {
+    "build-storybook": "build-storybook --stats-json"
+  }
+}
+```
+
+The stats file can be a bit challenging to read. Therefore, the Chromatic CLI offers a `trim-stats-file` option to make the file more human-readable. Use it like so:
 
 ```shell
 npx chromatic trim-stats-file
 ```
 
+Or, if you're using a custom build directory:
+
+```shell
+npx chromatic trim-stats-file ./path/to/preview-stats.json
+```
+
 ### Reading the trimmed stats file
-After running the above `trim-stats-file` command, Chromatic will output a `preview-stats.trimmed.json` file. While this file is more human-readable, it can still be a bit more confusing (though much less daunting than the non-trimmed file).
 
-Let's break down an example from the file!
-
-```json
-    {
-      "id": "./src/inputs/PinInput/PinInput.tsx",
-      "name": "./src/inputs/PinInput/PinInput.tsx + 4 modules",
-      "modules": [
-        { "name": "./src/inputs/PinInput/PinInput.tsx" },
-        { "name": "./src/inputs/PinInput/SeparatedPinInput.tsx" },
-        { "name": "./src/inputs/PinInput/SinglePinInput.tsx" },
-        { "name": "./src/inputs/utils.ts" },
-        { "name": "./src/inputs/PinInput/PinCaret.tsx" }
-      ],
-      "reasons": [
-        { "moduleName": "./src/data/DataGrid/cells/EditablePinInput.tsx" },
-        { "moduleName": "./src/inputs/PinInput/index.ts" }
-      ]
-    },
-```
-
-In the above example, we have an asset with the `chunkName` of `./src/inputs/PinInput/PinInput.tsx + 4 modules`. There's a total of five modules within this chunk (which we could likely gather from the name):
-
- 1. `./src/inputs/PinInput/PinInput.tsx`
- 2. `./src/inputs/PinInput/SeparatedPinInput.tsx`
- 3. `./src/inputs/PinInput/SinglePinInput.tsx`
- 4. `./src/inputs/utils.ts`
- 5. `./src/inputs/PinInput/PinCaret.tsx`
-
-Using the above information, we can identify that we have an asset that is one chunk containing five modules.
-
-Below the information that identifies the chunk, we see another set of modules under `reasons`. These are the modules that are part of the asset's dependency graph. In the above example, we have two modules that are dependent on this asset:
-
- 1. `./src/data/DataGrid/cells/EditablePinInput.tsx`
- 2. `./src/inputs/PinInput/index.ts`
-
-Using the modules `reasons`, we can identify that any changes to the asset chunk's modules may have an impact on the dependent modules.
-
-What's the asset object look like when it comes to story files? Usually a bit different:
+After running the `trim-stats-file` command, Chromatic will output a `preview-stats.trimmed.json` file. While this file is more readable, it can still be a bit daunting, so let's break it down with an example.
 
 ```json
-    {
-      "id": "./src/inputs/PinInput/stories/PinInput.stories.tsx",
-      "name": "./src/inputs/PinInput/stories/PinInput.stories.tsx + 4 modules",
-      "modules": [
-        { "name": "./src/inputs/PinInput/stories/PinInput.stories.tsx" },
-        { "name": "./src/inputs/PinInput/stories/PinInputWithNoCopyPaste.storyfile.tsx" },
-        { "name": "./src/inputs/PinInput/stories/PinInputWithNoCopyPaste.storyfile.tsx?raw" },
-        { "name": "./src/inputs/PinInput/stories/PinInputWithValidation.storyfile.tsx" },
-        { "name": "./src/inputs/PinInput/stories/PinInputWithValidation.storyfile.tsx?raw" }
-      ],
-      "reasons": [
-        { "moduleName": "./src/ lazy ^\\.\\/.*$ include: (?%21.*node_modules)(?:\\/src(?:\\/(?%21\\.)(?:(?:(?%21(?:^%7C\\/)\\.).)*?)\\/%7C\\/%7C$)(?%21\\.)(?=.)[^/]*?\\.stories\\.(js%7Cjsx%7Cts%7Ctsx))$ chunkName: [request] namespace object" }
-      ]
-    },
+{
+  "id": "./src/inputs/PinInput/PinInput.tsx",
+  "name": "./src/inputs/PinInput/PinInput.tsx + 4 modules",
+  "modules": [
+    { "name": "./src/inputs/PinInput/PinInput.tsx" },
+    { "name": "./src/inputs/PinInput/SeparatedPinInput.tsx" },
+    { "name": "./src/inputs/PinInput/SinglePinInput.tsx" },
+    { "name": "./src/inputs/utils.ts" },
+    { "name": "./src/inputs/PinInput/PinCaret.tsx" }
+  ],
+  "reasons": [
+    { "moduleName": "./src/data/DataGrid/cells/EditablePinInput.tsx" },
+    { "moduleName": "./src/inputs/PinInput/index.ts" }
+  ]
+}
 ```
 
-Under `reasons`, we see a `moduleName` that looks like a path pattern.  If you were to look at the non-trimmed file, you'd see the `issuerPath`'s are `"./storybook-config-entry.js"` and `"./storybook-stories.js"` because the dependency is the project's Storybook config:
+In this example, we have an asset with the `chunkName` of `./src/inputs/PinInput/PinInput.tsx + 4 modules`. There's a total of five modules within this chunk:
 
-```js
-// main.js
+```
+./src/inputs/PinInput/PinInput.tsx
+./src/inputs/PinInput/SeparatedPinInput.tsx
+./src/inputs/PinInput/SinglePinInput.tsx
+./src/inputs/utils.ts
+./src/inputs/PinInput/PinCaret.tsx
+```
 
+The `"reasons"` key provides information about the asset's dependency graph. In other words, modules that depend on this asset. Any changes to the asset chunk's modules may have an impact on its dependent modules:
+
+```
+./src/data/DataGrid/cells/EditablePinInput.tsx
+./src/inputs/PinInput/index.ts
+```
+
+### Asset object for a story file
+
+The asset object for a story file usually looks a bit different:
+
+```json
+{
+  "id": "./src/inputs/PinInput/stories/PinInput.stories.tsx",
+  "name": "./src/inputs/PinInput/stories/PinInput.stories.tsx + 4 modules",
+  "modules": [
+    { "name": "./src/inputs/PinInput/stories/PinInput.stories.tsx" },
+    {
+      "name": "./src/inputs/PinInput/stories/PinInputWithNoCopyPaste.storyfile.tsx"
+    },
+    {
+      "name": "./src/inputs/PinInput/stories/PinInputWithNoCopyPaste.storyfile.tsx?raw"
+    },
+    {
+      "name": "./src/inputs/PinInput/stories/PinInputWithValidation.storyfile.tsx"
+    },
+    {
+      "name": "./src/inputs/PinInput/stories/PinInputWithValidation.storyfile.tsx?raw"
+    }
+  ],
+  "reasons": [
+    {
+      "moduleName": "./src/ lazy ^\\.\\/.*$ include: (?%21.*node_modules)(?:\\/src(?:\\/(?%21\\.)(?:(?:(?%21(?:^%7C\\/)\\.).)*?)\\/%7C\\/%7C$)(?%21\\.)(?=.)[^/]*?\\.stories\\.(js%7Cjsx%7Cts%7Ctsx))$ chunkName: [request] namespace object"
+    }
+  ]
+}
+```
+
+Under `reasons`, you'll see a `moduleName` that looks like a path pattern. If you were to look at the non-trimmed file, you'd see the `issuerPath`'s are `"./storybook-config-entry.js"` and `"./storybook-stories.js"` because the dependency is the project's Storybook config:
+
+Under "reasons," you'll notice a `moduleName` resembling a path pattern. In the full, untrimmed file, the `issuerPath`'s are `"./storybook-config-entry.js"` and `"./storybook-stories.js"`. That's because the dependency is related to this project's Storybook configuration:
+
+```js title=".storybook/main.js"
 /** @type { import('@storybook/react-webpack5').StorybookConfig } */
 const config = {
-  stories: [{
-    directory: '../',
-    files: '**/*.@(mdx|stories.@(js|jsx|ts|tsx))',
-  }],
+  stories: [
+    {
+      directory: "../",
+      files: "**/*.@(mdx|stories.@(js|jsx|ts|tsx))",
+    },
+  ],
   // ...
 };
 export default config;
 ```
 
-Using the trimmed stats file, you can [search for a file path](/docs/turbosnap/troubleshooting/#why-are-no-changes-being-detected) to see whether it's part of the dependency graph for another module. 
+### Use the trimmed stats file to trace dependencies
+
+If you're trying to understand why a story file is being detected as changed, you can [search for its file path](/docs/turbosnap/troubleshooting/#why-are-no-changes-being-detected) in the trimmed stats file and trace its dependencies to see which modules were affected.
 
 ## Tracing dependencies with Vite
-Prior to Storybook v8, Vite was supported via the [`vite-plugin-turbosnap` by IanVS](https://github.com/IanVS/vite-plugin-turbosnap).  Starting in v8, the plugin has been integrated and TurboSnap supports Vite out-of-the-box.  The plugin does this by generating a `preview-stats.json` file after collecting information about each module being built and constructing a mapping between each file and all of the files which import it.  This mimics the file that is created by Webpack, with only the information that Chromatic's CLI needs to perform checks using TurboSnap.
+
+Before Storybook 8, Vite support for TurboSnap was available through the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap). Starting with version 8.0, this plugin has been integrated into Storybook, so TurboSnap now supports Vite natively.
+
+With Storybook 8.0+, you can can generate a stats file for Vite based projects by adding `--stats-json` to the `build-storybook` command:
+
+```json
+{
+  "scripts": {
+    "build-storybook": "build-storybook --stats-json"
+  }
+}
+```
+
+Whether using the plugin or Storybook 8.0+, the process is the same. When you run the `build-storybook` command, a `preview-stats.json` file is generated. This file collects information about each module being built and creates a mapping between each file and all the files that import it. It mimics the file created by Webpack but includes only the information that TurboSnap needs to perform dependency checks.

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -1,0 +1,105 @@
+---
+layout: "../../layouts/Layout.astro"
+title: TurboSnap Dependency Tracing
+description: Speed up tests by detecting file changes with Git
+sidebar: { order: 4, label: "Dependency Tracing" }
+slug: "turbosnap/dependency-tracing"
+---
+
+# TurboSnap Dependency Tracing
+TurboSnap analyzes both a project's git history and Webpack's dependency graph to identify which stories have been potentially impacted by changes.  But what is Webpack's dependency graph and how does TurboSnap use it to trace dependency changes?  How does this work for projects built with Vite?  This overview will answer these questions and help you better understand dependency tracing for TurboSnap.
+
+## Tracing dependencies with Webpack
+To start, let's visit [Webpack's dependency graph concept](https://webpack.js.org/concepts/dependency-graph/):
+
+> ❝ Any time one file depends on another, webpack treats this as a dependency. This allows webpack to take non-code assets, such as images or web fonts, and also provide them as dependencies for your application.
+> 
+> When webpack processes your application, it starts from a list of modules defined on the command line or in its configuration file. Starting from these [entry points](https://webpack.js.org/concepts/entry-points/), webpack recursively builds a dependency graph that includes every module your application needs, then bundles all of those modules into a small number of bundles - often, only one - to be loaded by the browser. ❞
+
+TurboSnap uses [Webpack's Stats Data API](https://webpack.js.org/api/stats) to generate a JSON file containing statistics about the modules for a project. These statistics are how TurboSnap analyzes a project's dependency graph, as it gives the details about the asset objects, any related chunks (or grouped modules), and the module dependencies that rely on the asset.
+
+This file is generated when a customer adds `--stats-json` (or `--webpack-stats-json` for SB versions < v8). Chromatic has an option called `trim-stats-file` that can be used to make the file more human-readable, since it can be a bit confusing to read through. Here's an example of the command used to run it, but a customer can add a path at the end if they want the stats file to built to a custom directory:
+
+```shell
+npx chromatic trim-stats-file
+```
+
+### Reading the trimmed stats file
+After running the above `trim-stats-file` command, Chromatic will output a `preview-stats.trimmed.json` file. While this file is more human-readable, it can still be a bit more confusing (though much less daunting than the non-trimmed file).
+
+Let's break down an example from the file!
+
+```json
+    {
+      "id": "./src/inputs/PinInput/PinInput.tsx",
+      "name": "./src/inputs/PinInput/PinInput.tsx + 4 modules",
+      "modules": [
+        { "name": "./src/inputs/PinInput/PinInput.tsx" },
+        { "name": "./src/inputs/PinInput/SeparatedPinInput.tsx" },
+        { "name": "./src/inputs/PinInput/SinglePinInput.tsx" },
+        { "name": "./src/inputs/utils.ts" },
+        { "name": "./src/inputs/PinInput/PinCaret.tsx" }
+      ],
+      "reasons": [
+        { "moduleName": "./src/data/DataGrid/cells/EditablePinInput.tsx" },
+        { "moduleName": "./src/inputs/PinInput/index.ts" }
+      ]
+    },
+```
+
+In the above example, we have an asset with the `chunkName` of `./src/inputs/PinInput/PinInput.tsx + 4 modules`. There's a total of five modules within this chunk (which we could likely gather from the name):
+
+ 1. `./src/inputs/PinInput/PinInput.tsx`
+ 2. `./src/inputs/PinInput/SeparatedPinInput.tsx`
+ 3. `./src/inputs/PinInput/SinglePinInput.tsx`
+ 4. `./src/inputs/utils.ts`
+ 5. `./src/inputs/PinInput/PinCaret.tsx`
+
+Using the above information, we can identify that we have an asset that is one chunk containing five modules.
+
+Below the information that identifies the chunk, we see another set of modules under `reasons`. These are the modules that are part of the asset's dependency graph. In the above example, we have two modules that are dependent on this asset:
+
+ 1. `./src/data/DataGrid/cells/EditablePinInput.tsx`
+ 2. `./src/inputs/PinInput/index.ts`
+
+Using the modules `reasons`, we can identify that any changes to the asset chunk's modules may have an impact on the dependent modules.
+
+What's the asset object look like when it comes to story files? Usually a bit different:
+
+```json
+    {
+      "id": "./src/inputs/PinInput/stories/PinInput.stories.tsx",
+      "name": "./src/inputs/PinInput/stories/PinInput.stories.tsx + 4 modules",
+      "modules": [
+        { "name": "./src/inputs/PinInput/stories/PinInput.stories.tsx" },
+        { "name": "./src/inputs/PinInput/stories/PinInputWithNoCopyPaste.storyfile.tsx" },
+        { "name": "./src/inputs/PinInput/stories/PinInputWithNoCopyPaste.storyfile.tsx?raw" },
+        { "name": "./src/inputs/PinInput/stories/PinInputWithValidation.storyfile.tsx" },
+        { "name": "./src/inputs/PinInput/stories/PinInputWithValidation.storyfile.tsx?raw" }
+      ],
+      "reasons": [
+        { "moduleName": "./src/ lazy ^\\.\\/.*$ include: (?%21.*node_modules)(?:\\/src(?:\\/(?%21\\.)(?:(?:(?%21(?:^%7C\\/)\\.).)*?)\\/%7C\\/%7C$)(?%21\\.)(?=.)[^/]*?\\.stories\\.(js%7Cjsx%7Cts%7Ctsx))$ chunkName: [request] namespace object" }
+      ]
+    },
+```
+
+Under `reasons`, we see a `moduleName` that looks like a path pattern.  If you were to look at the non-trimmed file, you'd see the `issuerPath`'s are `"./storybook-config-entry.js"` and `"./storybook-stories.js"` because the dependency is the project's Storybook config:
+
+```js
+// main.js
+
+/** @type { import('@storybook/react-webpack5').StorybookConfig } */
+const config = {
+  stories: [{
+    directory: '../',
+    files: '**/*.@(mdx|stories.@(js|jsx|ts|tsx))',
+  }],
+  // ...
+};
+export default config;
+```
+
+Using the trimmed stats file, you can [search for a file path](/docs/turbosnap/troubleshooting/#why-are-no-changes-being-detected) to see whether it's part of the dependency graph for another module. 
+
+## Tracing dependencies with Vite
+Prior to Storybook v8, Vite was supported via the [`vite-plugin-turbosnap` by IanVS](https://github.com/IanVS/vite-plugin-turbosnap).  Starting in v8, the plugin has been integrated and TurboSnap supports Vite out-of-the-box.  The plugin does this by generating a `preview-stats.json` file after collecting information about each module being built and constructing a mapping between each file and all of the files which import it.  This mimics the file that is created by Webpack, with only the information that Chromatic's CLI needs to perform checks using TurboSnap.


### PR DESCRIPTION
Proposing this page is added to detail TurboSnap dependency tracing.  I've been sending this information via a gist when customers want to have a deeper understanding of how tracing works and I thought it would be best to publish via the docs so this can be public/indexed.