### PR TITLE
Docs: E2E minor fixes

### DIFF
--- a/src/content/cypress/configure.md
+++ b/src/content/cypress/configure.md
@@ -12,27 +12,31 @@ You can enhance your Cypress and Chromatic tests further by configuring them usi
 
 ## Cypress options
 
-Cypress can be configured with [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables).
+Cypress can be configured with [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables). You can set the available options globally in your Cypress configuration file as follows:
 
-Setting options globally can be done in your Cypress config file as follows:
 
-```ts
-// cypress.config.ts
+```ts title="cypress.config.js|ts"
 export default defineConfig({
   env: {
+    // 👇 Sets the option at the project level.
     disableAutoSnapshot: true,
   },
-
-  // other setup...
+  // Other project configuration options
 });
 ```
 
-Options can also be overridden at the test level:
+You can also override them for specific tests using via the [`env`](https://docs.cypress.io/guides/guides/environment-variables#Suite-of-test-configuration) option in the test configuration:
 
-```ts
-// some-test.cy.ts
-it("A test that does something", { env: { disableAutoSnapshot: true } }, () => {
-  cy.visit("https://some-url.com");
+```ts title="cypress/e2e/HomePage.cy.js|ts"
+describe("HomePage", () => {
+  it("Loads the page with auto snapshotting disabled", {
+    env: {
+      // 👇 Overrides the option in the test.
+      disableAutoSnapshot: true,
+    },
+  }, () => {
+    cy.visit("/");
+  })
 });
 ```
 
@@ -40,24 +44,25 @@ it("A test that does something", { env: { disableAutoSnapshot: true } }, () => {
 
 These options control how the Chromatic archive fixture behaves.
 
-| Option                   | Type            | Description                                                                                                                                                                          |
-| ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disableAutoSnapshot`    | `boolean`       | When `true`, will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.                                                        |
-| `resourceArchiveTimeout` | `number`        | Maximum amount of time that each test will wait for the network to be idle while archiving resources.                                                                                |
-| `assetDomains`           | `array[string]` | A list of domains external to the test location that you want Chromatic to also capture assets from, e.g., <code style="display: inline;">['other-domain.com','our-cdn.com']</code>. |
+| Option                   | Type            | Description                                                                                                                                                                            |
+| ------------------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disableAutoSnapshot`    | `boolean`       | When `true`, it will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.                                                       |
+| `resourceArchiveTimeout` | `number`        | Maximum amount of time each test will wait for the network to be idle while archiving resources.                                                                                       |
+| `assetDomains`           | `array[string]` | A list of domains external to the test location that you want Chromatic to also capture assets from, e.g., <code style="display: inline;">['other-domain.com','our-cdn.com']</code>.   |
 
 ### Chromatic options
 
 These options control how Chromatic behaves when capturing snapshots of your pages.
 
-| Option                    | Type      | Chromatic Docs                                                          |
-| ------------------------- | --------- | ----------------------------------------------------------------------- |
-| `delay`                   | `number`  | [Delay](/docs/delay/)                                                   |
-| `diffIncludeAntiAliasing` | `boolean` | [Threshold for changes](/docs/threshold#anti-aliasing)                  |
-| `diffThreshold`           | `number`  | [Threshold for changes](/docs/threshold#setting-the-threshold)          |
-| `forcedColors`            | `string`  | [Media Features](/docs/media-features#test-high-contrast-color-schemes) |
-| `pauseAnimationAtEnd`     | `boolean` | [Animations](/docs/animations#css-animations)                           |
-| `prefersReducedMotion`    | `string`  | [Media Features](/docs/media-features#verify-reduced-motion-animations) |
+| Option                    | Type            | Chromatic Docs                                                                      |
+| ------------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| `delay`                   | `number`        | [Delay](/docs/delay/)                                                               |
+| `diffIncludeAntiAliasing` | `boolean`       | [Threshold for changes](/docs/threshold#anti-aliasing)                              |
+| `diffThreshold`           | `number`        | [Threshold for changes](/docs/threshold#setting-the-threshold)                      |
+| `ignoreSelectors`         | `array[string]` | [Ignore elements](/docs/ignoring-elements#ignoring-elements-via-test-configuration) |
+| `forcedColors`            | `string`        | [Media Features](/docs/media-features#test-high-contrast-color-schemes)             |
+| `pauseAnimationAtEnd`     | `boolean`       | [Animations](/docs/animations#css-animations)                                       |
+| `prefersReducedMotion`    | `string`        | [Media Features](/docs/media-features#verify-reduced-motion-animations)             |
 
 ### Environment variables
 
@@ -71,11 +76,11 @@ Some options can be configured through environment variables.
 
 ## Viewports
 
-Chromatic will capture the DOM and take snapshots at each viewport size a test is configured to run in.
+Chromatic will capture the DOM and take snapshots at each viewport size in which a test is configured to run.
 
-[Viewports in Cypress](https://docs.cypress.io/api/commands/viewport) can be configured [globally in you main cypress config file](https://docs.cypress.io/api/commands/viewport#Default-sizing) as follows:
+[Viewports in Cypress](https://docs.cypress.io/api/commands/viewport) can be configured [globally in your main Cypress configuration file](https://docs.cypress.io/api/commands/viewport#Default-sizing) as follows:
 
-```javascript
+```ts title="cypress.config.js|ts"
 import { defineConfig } from "cypress";
 
 export default defineConfig({
@@ -86,16 +91,17 @@ export default defineConfig({
 
 Or using [configuration at the test level](https://docs.cypress.io/api/commands/viewport#Set-viewport-in-the-test-configuration):
 
-```javascript
+```ts title="cypress/e2e/Viewports.cy.js|ts"
 describe(
-  "page display on medium size screen",
+  "Page display on medium size screen",
   {
+    // 👇 Overrides the option in the test.
     viewportHeight: 1000,
     viewportWidth: 400,
   },
   () => {
-    it("does not display sidebar", () => {
-      // ...
+    it("Does not display sidebar", () => {
+      cy.visit("/");
     });
   },
 );
@@ -103,6 +109,6 @@ describe(
 
 <div class="aside">
 
-Note: Currently, setting the viewport using `cy.viewport()` is not supported.
+ℹ️ Currently, setting the viewport using `cy.viewport()` is not supported.
 
 </div>

--- a/src/content/playwright/configure.mdx
+++ b/src/content/playwright/configure.mdx
@@ -14,60 +14,47 @@ You can enhance your Playwright and Chromatic tests further by configuring them 
 
 ## Playwright options
 
-The Chromatic [Playwright Fixture](https://playwright.dev/docs/test-fixtures) can be configured with `use` like all [Playwright options](https://playwright.dev/docs/test-use-options).
-
-Setting options globally can be done in your `playwright.config.js` as follows:
+The Chromatic [Playwright Fixture](https://playwright.dev/docs/test-fixtures) can be configured with `use` like all [Playwright options](https://playwright.dev/docs/test-use-options). You can set the available options globally in your Playwright configuration file as follows:
 
 <Tabs>
   <TabItem label="TypeScript">
-    ```ts
-    // playwright.config.ts
+    ```ts title="playwright.config.ts"
     import { defineConfig } from "@playwright/test";
     import { ChromaticConfig } from "@chromatic-com/playwright";
 
     export default defineConfig<ChromaticConfig>({
       use: {
-        // ...
-
-        // 👇 your option overrides
+        // 👇 Sets the option at the project level.
         disableAutoSnapshot: true,
       },
-      // ... your other configuration
+      // Other project configuration options
     });
     ```
-
   </TabItem>
     <TabItem label="JavaScript">
-    ```javascript
-    // playwright.config.js
-
+    ```js title="playwright.config.js"
     import { defineConfig } from "@playwright/test";
 
     export default defineConfig({
       use: {
-        // ...
-
-        // 👇 your global options
+        // 👇 Sets the option at the project level.
         disableAutoSnapshot: true,
       },
-      // ... your other configuration
+      // Other project configuration options
     });
     ```
-
   </TabItem>
 </Tabs>
 
-Options can also be overridden at the test level:
+You can also override them for specific tests by adding the [`test.use()`](https://playwright.dev/docs/api/class-test#test-use) method in your test file and provide the required options:
 
-```javascript
-// mytest.spec.js
-
-test.describe("some block", () => {
-  // 👇 your option overrides
+```ts title="HomePage.spec.js|ts"
+test.describe("HomePage", () => {
+  // 👇 Overrides the option in the test.
   test.use({ disableAutoSnapshot: true });
 
-  test("some test", async ({ page }) => {
-    // ...
+  test("Loads the page with auto snapshotting disabled", async ({ page }) => {
+    await page.goto("/");
   });
 });
 ```
@@ -78,22 +65,23 @@ These options control how the Chromatic archive fixture behaves.
 
 | Option                   | Type            | Description                                                                                                                                                                          |
 | ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disableAutoSnapshot`    | `boolean`       | When `true`, will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.                                                        |
-| `resourceArchiveTimeout` | `number`        | Maximum amount of time that each test will wait for the network to be idle while archiving resources.                                                                                |
+| `disableAutoSnapshot`    | `boolean`       | When `true`, it will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.                                                     |
+| `resourceArchiveTimeout` | `number`        | Maximum amount of time each test will wait for the network to be idle while archiving resources.                                                                                     |
 | `assetDomains`           | `array[string]` | A list of domains external to the test location that you want Chromatic to also capture assets from, e.g., <code style="display: inline;">['other-domain.com','our-cdn.com']</code>. |
 
 ## Chromatic options
 
 These options control how Chromatic behaves when capturing snapshots of your pages.
 
-| Option                    | Type      | Chromatic Docs                                                          |
-| ------------------------- | --------- | ----------------------------------------------------------------------- |
-| `delay`                   | `number`  | [Delay](/docs/delay/)                                                   |
-| `diffIncludeAntiAliasing` | `boolean` | [Threshold for changes](/docs/threshold#anti-aliasing)                  |
-| `diffThreshold`           | `number`  | [Threshold for changes](/docs/threshold#setting-the-threshold)          |
-| `forcedColors`            | `string`  | [Media Features](/docs/media-features#test-high-contrast-color-schemes) |
-| `pauseAnimationAtEnd`     | `boolean` | [Animations](/docs/animations#css-animations)                           |
-| `prefersReducedMotion`    | `string`  | [Media Features](/docs/media-features#verify-reduced-motion-animations) |
+| Option                    | Type            | Chromatic Docs                                                                      |
+| ------------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| `delay`                   | `number`        | [Delay](/docs/delay/)                                                               |
+| `diffIncludeAntiAliasing` | `boolean`       | [Threshold for changes](/docs/threshold#anti-aliasing)                              |
+| `diffThreshold`           | `number`        | [Threshold for changes](/docs/threshold#setting-the-threshold)                      |
+| `ignoreSelectors`         | `array[string]` | [Ignore elements](/docs/ignoring-elements#ignoring-elements-via-test-configuration) |
+| `forcedColors`            | `string`        | [Media Features](/docs/media-features#test-high-contrast-color-schemes)             |
+| `pauseAnimationAtEnd`     | `boolean`       | [Animations](/docs/animations#css-animations)                                       |
+| `prefersReducedMotion`    | `string`        | [Media Features](/docs/media-features#verify-reduced-motion-animations)             |
 
 ## Environment variables
 
@@ -107,12 +95,13 @@ Some options can be configured through environment variables.
 
 ## Viewports
 
-Chromatic will capture the DOM and take snapshots at each viewport size a test is configured to run in.
+Chromatic will capture the DOM and take snapshots at each viewport size in which a test is configured to run.
 
-[Viewports in Playwright](https://playwright.dev/docs/emulation#viewport) can be configured globally in you main playwright config file as follows:
+[Viewports in Playwright](https://playwright.dev/docs/emulation#viewport) can be configured globally in your main Playwright configuration file as follows:
 
-```javascript
+```ts title="playwright.config.js|ts"
 import { defineConfig } from "@playwright/test";
+
 export default defineConfig({
   projects: [
     {
@@ -135,13 +124,16 @@ export default defineConfig({
 
 Or at the test level:
 
-```javascript
-test.use({
-  viewport: { width: 1600, height: 1200 },
-});
+```ts title="Viewports.spec.js|ts"
+test.describe("Page display on medium size screen", () => {
+  // 👇 Overrides the option in the test.
+  test.use({
+    viewport: { width: 1600, height: 1200 },
+  });
 
-test("my test", async ({ page }) => {
-  // ...
+  test("Does not display sidebar", async ({ page }) => {
+    await page.goto("/");
+  });
 });
 ```
 
@@ -151,7 +143,7 @@ test("my test", async ({ page }) => {
 
 Often, when using a monorepo, developers tend to keep their e2e tests in a subdirectory instead of in the root of the project. At the same time, the Storybook and Chromatic configuration details live at the project’s root. In these cases, you will need to update the `archive-storybook` and `build-archive-storybook` scripts in your `package.json` by setting the [`-c` flag](https://storybook.js.org/docs/api/cli-options#build) and `CHROMATIC_ARCHIVE_LOCATION` environment variable. For example:
 
-```json
+```json title="package.json"
 "scripts": {
   "archive-storybook": "CHROMATIC_ARCHIVE_LOCATION=path/to/test-results archive-storybook -c path/to/node_modules/@chromaui/archive-storybook/config",
   "build-archive-storybook": "CHROMATIC_ARCHIVE_LOCATION=path/to/test-results build-archive-storybook -c path/to/node_modules/@chromaui/archive-storybook/config"

--- a/src/content/snapshotOptions/ignoring-elements.mdx
+++ b/src/content/snapshotOptions/ignoring-elements.mdx
@@ -42,7 +42,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
 ## Ignoring elements via test configuration
 
-To ignore multiple elements at once, you can specify a list of selectors in the `ignoreSelectors` parameter. This support any valid CSS selector, such as `.any-selector-the-browser-supports`, `#even-really-weird-ones`, or `a[href$=".zip" i]:after`
+You can specify a list of CSS selectors with the `ignoreSelectors` option to ignore multiple elements simultaneously. This option supports valid CSS selectors, such as `.any-selector-the-browser-supports`, `#even-really-weird-ones`, or `a[href$=".zip" i]:after`.
 
 {/* prettier-ignore-start */}
 
@@ -118,7 +118,7 @@ To ignore multiple elements at once, you can specify a list of selectors in the 
 
 ## Dimension changes in ignored elements still trigger diffs
 
-Adding the `data-chromatic="ignore"` attribute or specifying a selector in `ignoreSelectors` param instructs the diffing algorithm to disregard pixels within the bounding box of the ignored element. However, dimension changes of this element still trigger a change.
+Adding the `data-chromatic="ignore"` attribute or specifying a selector with the `ignoreSelectors` option instructs the diffing algorithm to disregard pixels within the bounding box of the ignored element. However, dimension changes of this element still trigger a change.
 
 Ensure that both the baseline and new snapshots maintain the exact dimensions, such as width, height, and relative positioning.
 


### PR DESCRIPTION
Follow up on #570.

With this small pull request, the Cypress, Playwright, and Ignore elements documentation was updated to reflect the new changes introduced by the mentioned pull request.

What was done:
- Added the new option (i.e., the `ignoreSelectors` option to the E2E configuration documentation as we're providing references in the Ignore tests documentation and we didn't include it)
- Polished said documentation, including the examples.
- Minor adjustments to the Ignore elements documentation to align the terminology and fix some typos

@winkerVSbecks, when you have a moment, can you take a look and follow up with me with any feedback you may have? Thanks in advance.