### PR TITLE
Add `--build-command` flag

### DIFF
--- a/chromatic-config/options.json
+++ b/chromatic-config/options.json
@@ -18,6 +18,14 @@
     "supports": ["CLI", "GitHub Action"]
   },
   {
+    "option": "buildCommand",
+    "flag": "--build-command",
+    "description": "The command that builds your Storybook. Use this if your Storybook build command does not exist in the \"scripts\" field of your package.json.<br/>Requires `--output-dir`.",
+    "type": "string",
+    "example": "`\"nx run my-app:build-storybook\"`",
+    "supports": ["CLI", "GitHub Action", "Config File"]
+  },
+  {
     "option": "buildScriptName",
     "flag": "--build-script-name",
     "shortFlag": "-b",


### PR DESCRIPTION
A `--build-command` flag was added to the CLI (https://github.com/chromaui/chromatic-cli/pull/1109) so here's the docs side of things!

![image](https://github.com/user-attachments/assets/4abd31de-54e8-480b-8179-2ed99e03782a)
