### PR TITLE
Update `exitZeroOnChanges` default value

### DIFF
--- a/chromatic-config/options.json
+++ b/chromatic-config/options.json
@@ -96,7 +96,7 @@
     "description": "If all snapshots render, but there are visual changes, exit with code `0` rather than the usual exit code `1`. Only for given branch, if specified.",
     "type": ["glob", "boolean"],
     "example": "`\"!(main)\"` or `true`",
-    "default": false,
+    "defaultComment": "`true` in the GitHub Action, otherwise `false`",
     "supports": ["CLI", "GitHub Action", "Config File"]
   },
   {

--- a/src/components/ConfigurationOptions/ConfigurationOptions.astro
+++ b/src/components/ConfigurationOptions/ConfigurationOptions.astro
@@ -14,7 +14,7 @@ export const formatOption = async (option: ConfigOptionType) => {
     default:
       option.default !== undefined
         ? `<code>${option.default}</code>`
-        : option.defaultComment,
+        : await markdown(option.defaultComment),
   };
 };
 


### PR DESCRIPTION
Also add markdown support on `defaultComment` value for that to work as I would like.

![Screenshot 2024-12-03 at 9 47 58 AM](https://github.com/user-attachments/assets/15742703-59a8-4101-8c70-29d89bb87e80)
