### PR TITLE
Clarifies that preferMergedBaselines is a feature request

### DIFF
--- a/src/content/snapshot/branching-and-baselines.md
+++ b/src/content/snapshot/branching-and-baselines.md
@@ -111,7 +111,7 @@ Consider a busy repository where many people are working on the same UI. An issu
 
 As Chromatic picks the latest accepted changes, that can often mean it picks your baselines instead of incoming baselines. This results in you having to re-accept the changes the other person made which you might not have the context on.
 
-While Chromatic’s default of choosing latest accepted baseline works for most teams, you may want to change the behavior for your team. If you want Chromatic to always prefer the “incoming” baselines to avoid re-accepting changes, please [email](mailto:support@chromatic.com) support and request the `preferMergedBaselines` feature be enabled for your account.
+Chromatic’s default of choosing latest accepted baseline works for most teams. If you want Chromatic to always prefer the “incoming” baselines to avoid re-accepting changes, please [email](mailto:support@chromatic.com) support to express your interest in the feature request for the `preferMergedBaselines` feature.
 
 </details>
 


### PR DESCRIPTION
Folks often write in asking us to enable `preferMergedBaselines`, but we're no longer doing so due to [technical/performance limitations](https://app.getguru.com/card/iLMpXBnT/GraphQL-Mutation-Enable-preferMergedBaselines-feature).

This change reworks this FAQ to emphasize Chromatic's default behavior. It suggests reaching out to be added to the _feature request_  so that we can still track their interest and notify them once it becomes available.