### PR TITLE
Docs: Configuration reference fix incorrrect link

### DIFF
--- a/chromatic-config/options.json
+++ b/chromatic-config/options.json
@@ -144,7 +144,7 @@
   },
   {
     "flag": "--list",
-    "description": "Outputs the list of available stories in your Storybook.<br/>Useful for [debugging and diagnosing issues](#diagnosing-issues).",
+    "description": "Outputs the list of available stories in your Storybook.<br/>Useful for [debugging and diagnosing issues](/docs/cli#flags-to-help-diagnose-build-issues-with-the-cli).",
     "type": "boolean",
     "example": "`true`",
     "default": false,


### PR DESCRIPTION
With this pull request, the configuration reference file was updated to fix an incorrectly generated link in the `--list` option.

What was done:
- Adjusted the `--list` option link to prevent it from scrolling to the top of the documentation, instead of the correct place.


@winkerVSbecks, when you have a moment, can you take a look and let me know of any feedback you may have? Thanks in advance.