### PR TITLE
Fix erroneous reference to Cypress

### DIFF
--- a/src/content/playwright/setup.mdx
+++ b/src/content/playwright/setup.mdx
@@ -49,7 +49,7 @@ Generate a unique project token for your app by signing in to Chromatic and crea
 
 <div class="callout">
   If your repository already has a Chromatic project linked to it, you can
-  create an additional Chromatic project to run visual tests with Cypress.
+  create an additional Chromatic project to run visual tests with Playwright.
   Follow the instructions for [sub-projects support](/docs/combine-stories-e2e).
 </div>
 


### PR DESCRIPTION
A customer pointed out a misprint in our Playwright docs:

> If your repository already has a Chromatic project linked to it, you can create an additional Chromatic project to run visual tests with **_Cypress_**.

This corrects that.