### PR TITLE
Adds FAQ explaining why tests show as new

### DIFF
--- a/src/content/troubleshooting/faq/why-tests-show-as-new.md
+++ b/src/content/troubleshooting/faq/why-tests-show-as-new.md
@@ -7,17 +7,17 @@ section: "uiTestsAndReview"
 
 # Why do tests show as new in builds?
 
-Tests are identified by their **story name**, which is a combination of key elements in the test file. If any of these elements change, the test will be considered new. Here's a breakdown of how story names are constructed and why they might change.
+Tests are identified by their **test name**, which is a combination of key elements in the test file. If any of these elements change, the test will be considered new. Here's a breakdown of how test names are constructed and why they might change.
 
-## Story Name Construction
+## Test Name Construction
 
-The story name is generated from:
+The test name is generated from:
 
 1. **File Name**: The name of the test file (e.g., `spec.cy.ts`).
 2. **Describe Block**: The names of `describe` blocks that organize and group related tests.
 3. **It Block**: The name of the specific test within the `it` block.
 
-If **any** of these elements change—file name, `describe` block name, or `it` block name—the story name changes. As a result, Chromatic interprets the test as new because it no longer matches the previously known story name.
+If **any** of these elements change—file name, `describe` block name, or `it` block name—the test name changes. As a result, Chromatic interprets the test as new because it no longer matches the previously known test name.
 
 ### Example
 
@@ -27,13 +27,13 @@ Consider the following test file structure:
 - **Describe block**: `template spec`
 - **It block**: `loads homepage`
 
-The story name for this test would be:
-`spec.cy.ts > template spec > loads homepage`
+The name for this test would be:
+`spec/template spec/loads homepage`
 
-## How to Avoid Unintentional New Stories
+## How to Avoid Unintentional New Tests
 
 To prevent tests from showing as new unintentionally:
 
 - **Keep naming consistent**: Avoid renaming files, `describe` blocks, or `it` blocks unless necessary.
-- **Refactor carefully**: If changes are needed, be aware that the story name will change, and Chromatic will treat it as new.
+- **Refactor carefully**: If changes are needed, be aware that the test name will change, and Chromatic will treat it as new.
 - **Review build diffs**: If a test appears as new, check whether the naming structure has been altered.

--- a/src/content/troubleshooting/faq/why-tests-show-as-new.md
+++ b/src/content/troubleshooting/faq/why-tests-show-as-new.md
@@ -7,7 +7,7 @@ section: "uiTestsAndReview"
 
 # Why do tests show as new in builds?
 
-Tests are identified by their **story name**, which is a combination of key elements in the test file. If any of these elements change, the test will be considered new. Here's a breakdown of how story names are constructed and why they might change:
+Tests are identified by their **story name**, which is a combination of key elements in the test file. If any of these elements change, the test will be considered new. Here's a breakdown of how story names are constructed and why they might change.
 
 ## Story Name Construction
 
@@ -16,6 +16,8 @@ The story name is generated from:
 1. **File Name**: The name of the test file (e.g., `spec.cy.ts`).
 2. **Describe Block**: The names of `describe` blocks that organize and group related tests.
 3. **It Block**: The name of the specific test within the `it` block.
+
+If **any** of these elements change—file name, `describe` block name, or `it` block name—the story name changes. As a result, Chromatic interprets the test as new because it no longer matches the previously known story name.
 
 ### Example
 
@@ -27,16 +29,6 @@ Consider the following test file structure:
 
 The story name for this test would be:
 `spec.cy.ts > template spec > loads homepage`
-
-## Why a Test Shows as New
-
-If **any** of these elements change—file name, `describe` block name, or `it` block name—the story name changes. As a result, Chromatic interprets the test as new because it no longer matches the previously known story name.
-
-### Examples of Changes:
-
-1. Renaming the file from `spec.cy.ts` to `home.cy.ts`.
-2. Updating the `describe` block from `template spec` to `homepage spec`.
-3. Modifying the `it` block from `loads homepage` to `renders homepage`.
 
 ## How to Avoid Unintentional New Stories
 

--- a/src/content/troubleshooting/faq/why-tests-show-as-new.md
+++ b/src/content/troubleshooting/faq/why-tests-show-as-new.md
@@ -43,5 +43,5 @@ If **any** of these elements change—file name, `describe` block name, or `it` 
 To prevent tests from showing as new unintentionally:
 
 - **Keep naming consistent**: Avoid renaming files, `describe` blocks, or `it` blocks unless necessary.
-- **Refactor carefully**: If changes are needed, be aware that the story name will change, and Chromatic will treat it as a new story.
+- **Refactor carefully**: If changes are needed, be aware that the story name will change, and Chromatic will treat it as new.
 - **Review build diffs**: If a test appears as new, check whether the naming structure has been altered.

--- a/src/content/troubleshooting/faq/why-tests-show-as-new.md
+++ b/src/content/troubleshooting/faq/why-tests-show-as-new.md
@@ -1,0 +1,47 @@
+---
+layout: "../../../layouts/FAQLayout.astro"
+sidebar: { hide: true }
+title: Why do tests show as new in builds?
+section: "uiTestsAndReview"
+---
+
+# Why do tests show as new in builds?
+
+Tests are identified by their **story name**, which is a combination of key elements in the test file. If any of these elements change, the test will be considered new. Here's a breakdown of how story names are constructed and why they might change:
+
+## Story Name Construction
+
+The story name is generated from:
+
+1. **File Name**: The name of the test file (e.g., `spec.cy.ts`).
+2. **Describe Block**: The names of `describe` blocks that organize and group related tests.
+3. **It Block**: The name of the specific test within the `it` block.
+
+### Example
+
+Consider the following test file structure:
+
+- **File name**: `spec.cy.ts`
+- **Describe block**: `template spec`
+- **It block**: `loads homepage`
+
+The story name for this test would be:
+`spec.cy.ts > template spec > loads homepage`
+
+## Why a Test Shows as New
+
+If **any** of these elements change—file name, `describe` block name, or `it` block name—the story name changes. As a result, Chromatic interprets the test as new because it no longer matches the previously known story name.
+
+### Examples of Changes:
+
+1. Renaming the file from `spec.cy.ts` to `home.cy.ts`.
+2. Updating the `describe` block from `template spec` to `homepage spec`.
+3. Modifying the `it` block from `loads homepage` to `renders homepage`.
+
+## How to Avoid Unintentional New Stories
+
+To prevent tests from showing as new unintentionally:
+
+- **Keep naming consistent**: Avoid renaming files, `describe` blocks, or `it` blocks unless necessary.
+- **Refactor carefully**: If changes are needed, be aware that the story name will change, and Chromatic will treat it as a new story.
+- **Review build diffs**: If a test appears as new, check whether the naming structure has been altered.


### PR DESCRIPTION
Explain why E2E tests would show as new in builds.