### PR TITLE
Docs: CI updates Playwright and Cypress images

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -153,7 +153,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Cypress
             displayName: "Run Cypress"
-            container: cypress/browsers:node-22.12.0-chrome-131.0.6778.139-1-ff-133.0.3-edge-131.0.2903.99-1
+            container: cypress/browsers:node-22.13.1-chrome-132.0.6834.83-1-ff-134.0.2-edge-132.0.2957.115-1
             variables:
               npm_config_cache: $(Pipeline.Workspace)/.npm
             steps:

--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -71,7 +71,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.49.0-noble
+            container: mcr.microsoft.com/playwright:v1.50.0-noble
             steps:
               - checkout: self
                 displayName: "Get Full Git History"

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -96,7 +96,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - step:
                 name: "Cypress"
                 # Configure the ELECTRON_EXTRA_LAUNCH_ARGS environment variable in your project settings to run Cypress tests with Chromatic.
-                image: cypress/browsers:node-22.12.0-chrome-131.0.6778.139-1-ff-133.0.3-edge-131.0.2903.99-1
+                image: cypress/browsers:node-22.13.1-chrome-132.0.6834.83-1-ff-134.0.2-edge-132.0.2957.115-1
                 caches:
                   - npm
                   - node

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -57,7 +57,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.49.0-noble
+                  image: mcr.microsoft.com/playwright:v1.50.0-noble
                   caches:
                     - npm
                     - node

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -131,7 +131,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       cypress:
         docker:
-          - image: cypress/browsers:node-22.12.0-chrome-131.0.6778.139-1-ff-133.0.3-edge-131.0.2903.99-1
+          - image: cypress/browsers:node-22.13.1-chrome-132.0.6834.83-1-ff-134.0.2-edge-132.0.2957.115-1
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-noble-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.49.0-noble
+          - image: mcr.microsoft.com/playwright:v1.50.0-noble
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -68,7 +68,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Cypress"
         displayName: "Run Cypress tests"
-        container: cypress/browsers:node-22.12.0-chrome-131.0.6778.139-1-ff-133.0.3-edge-131.0.2903.99-1
+        container: cypress/browsers:node-22.13.1-chrome-132.0.6834.83-1-ff-134.0.2-edge-132.0.2957.115-1
         environment:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         options:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -42,7 +42,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.49.0-noble
+        container: mcr.microsoft.com/playwright:v1.50.0-noble
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -56,7 +56,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.49.0-noble
+          image: mcr.microsoft.com/playwright:v1.50.0-noble
         steps:
           - uses: actions/checkout@v4
             with:

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -120,7 +120,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         name: Run Cypress
         runs-on: ubuntu-latest
         container:
-          image: cypress/browsers:node-22.12.0-chrome-131.0.6778.139-1-ff-133.0.3-edge-131.0.2903.99-1
+          image: cypress/browsers:node-22.13.1-chrome-132.0.6834.83-1-ff-134.0.2-edge-132.0.2957.115-1
           options: --user 1001
         steps:
           - uses: actions/checkout@v4

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -99,7 +99,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Cypress:
       stage: UI_Tests
       needs: []
-      image: cypress/browsers:node-22.12.0-chrome-131.0.6778.139-1-ff-133.0.3-edge-131.0.2903.99-1
+      image: cypress/browsers:node-22.13.1-chrome-132.0.6834.83-1-ff-134.0.2-edge-132.0.2957.115-1
       variables:
         ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
       script:

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.49.0-noble
+      image: mcr.microsoft.com/playwright:v1.50.0-noble
       script:
         - npx playwright test
       allow_failure: true

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -94,7 +94,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Cypress') {
            agent {
              docker {
-               image 'cypress/browsers:node-22.12.0-chrome-131.0.6778.139-1-ff-133.0.3-edge-131.0.2903.99-1'
+               image 'cypress/browsers:node-22.13.1-chrome-132.0.6834.83-1-ff-134.0.2-edge-132.0.2957.115-1'
                reuseNode true
              }
            }

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -51,7 +51,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.49.0-noble'
+               image 'mcr.microsoft.com/playwright:v1.50.0-noble'
                reuseNode true
              }
            }

--- a/src/content/ci/semaphore.mdx
+++ b/src/content/ci/semaphore.mdx
@@ -74,7 +74,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               os_image: ubuntu2204
             containers:
               - name: Plawyright
-                image: mcr.microsoft.com/playwright:v1.49.0-noble
+                image: mcr.microsoft.com/playwright:v1.50.0-noble
           jobs:
             - name: Run Playwright
               commands:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -27,7 +27,7 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.49.0-noble
+      image: mcr.microsoft.com/playwright:v1.50.0-noble
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,7 +97,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.49.0-noble
+  image: mcr.microsoft.com/playwright:v1.50.0-noble
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -123,7 +123,7 @@ version: 2.1
 executors:
   pw-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.49.0-noble
+      - image: mcr.microsoft.com/playwright:v1.50.0-noble
   chromatic-ui-testing:
     docker:
       - image: cimg/node:22.12.0
@@ -201,7 +201,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.49.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.50.0-noble'
               reuseNode true
             }
           }
@@ -221,7 +221,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.49.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.50.0-noble'
               reuseNode true
             }
           }
@@ -279,7 +279,7 @@ blocks:
           os_image: ubuntu2204
         containers:
           - name: Plawyright
-            image: mcr.microsoft.com/playwright:v1.49.0-noble
+            image: mcr.microsoft.com/playwright:v1.50.0-noble
       jobs:
         - name: Run Playwright
           commands:
@@ -318,7 +318,7 @@ image: node:jod
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.49.0-noble
+    container: mcr.microsoft.com/playwright:v1.50.0-noble
     options:
       parallel: 2
       artifacts:


### PR DESCRIPTION
With this pull request, the Docker images used in the documentation for Playwright and Cypress were updated to the latest version to avoid outdated versions and browsers with some security vulnerabilities.

What was done:
- Updated the image references for both Playwright and Cypress to the latest stable versions for security reasons

@winkerVSbecks, when you have a moment, can you look into this and let me know if you have any feedback? Thanks in advance
