### PR TITLE
Clarify on-premise or self-managed git providers require Enterprise plan

### DIFF
--- a/src/content/collaborate/access.md
+++ b/src/content/collaborate/access.md
@@ -17,7 +17,7 @@ Sign in to Chromatic via OAuth, email, or SSO.
 
 Chromatic supports the cloud versions of GitHub, GitLab, or Bitbucket on our [self-serve plans](https://www.chromatic.com/pricing).
 
-If you use the on-premise or enterprise versions of GitHub, GitLab, or Bitbucket, we can support you via our [enterprise plan](https://www.chromatic.com/pricing). We recommend trialing Chromatic first by following these [instructions](/docs/faq/chromatic-sso-on-premises-other-git).
+If you use the on-premise or self-managed versions of GitHub, GitLab, or Bitbucket, we can support you via our [enterprise plan](https://www.chromatic.com/pricing). We recommend trialing Chromatic first by following these [instructions](/docs/faq/chromatic-sso-on-premises-other-git).
 
 <details>
     <summary>What OAuth scopes does Chromatic request?</summary>


### PR DESCRIPTION
It wasn't super clear to me that GitHub.com Enterprise doesn't require an enterprise plan. This PR improves the language used to make that clearer.