### PR TITLE
Docs: E2E Add BDD support

### DIFF
--- a/src/content/playwright/setup.mdx
+++ b/src/content/playwright/setup.mdx
@@ -221,3 +221,10 @@ No. Playwright is a "black box" tool that tests your fully built app UI in a bro
 Chromatic creates and runs a Storybook [archive](/docs/faq/what-is-archive) based on your Playwright project, so the build Storybook step is required. Chromatic doesn't run Playwright directly.
 
 </details>
+
+<details>
+<summary id="third-party-integrations">Can I use custom fixtures with Playwright visual tests?</summary>
+
+Chromatic’s Playwright integration is designed to work with third-party integrations and tools. It allows you to combine your existing fixtures via the [`mergeTests`](https://playwright.dev/docs/test-fixtures#combine-custom-fixtures-from-multiple-modules) option. See our FAQ on [BDD support with Playwright](/docs/faq/bdd-with-playwright) to learn more.
+
+</details>

--- a/src/content/troubleshooting/faq.mdx
+++ b/src/content/troubleshooting/faq.mdx
@@ -109,13 +109,3 @@ If you have a question not covered in our documentation, contact us via our in-a
     </li>
   ))}
 </ul>
-
-## E2E
-
-<ul class="faq-section-toc">
-  {props.groupedFAQs.E2E.map((faq) => (
-    <li>
-      <a href={`/docs/${faq.slug}`}>{faq.title}</a>
-    </li>
-  ))}
-</ul>

--- a/src/content/troubleshooting/faq.mdx
+++ b/src/content/troubleshooting/faq.mdx
@@ -109,3 +109,13 @@ If you have a question not covered in our documentation, contact us via our in-a
     </li>
   ))}
 </ul>
+
+## E2E
+
+<ul class="faq-section-toc">
+  {props.groupedFAQs.E2E.map((faq) => (
+    <li>
+      <a href={`/docs/${faq.slug}`}>{faq.title}</a>
+    </li>
+  ))}
+</ul>

--- a/src/content/troubleshooting/faq/bdd-with-playwright.mdx
+++ b/src/content/troubleshooting/faq/bdd-with-playwright.mdx
@@ -2,7 +2,7 @@
 layout: "../../../layouts/FAQLayout.astro"
 sidebar: { hide: true }
 title: Can I use BDD with Playwright?
-section: E2E
+section: "uiTestsAndReview"
 ---
 
 import { TabItem, Tabs } from "../../../components/Tabs";

--- a/src/content/troubleshooting/faq/bdd-with-playwright.mdx
+++ b/src/content/troubleshooting/faq/bdd-with-playwright.mdx
@@ -1,0 +1,86 @@
+---
+layout: "../../../layouts/FAQLayout.astro"
+sidebar: { hide: true }
+title: Can I use BDD with Playwright?
+section: E2E
+---
+
+import { TabItem, Tabs } from "../../../components/Tabs";
+
+# Can I use BDD with Playwright?
+
+Testing with Behavior-Driven Development (BDD) is not supported by default with the Playwright integration, and you'll have to rely on a third-party integration such as [Playwright BDD](https://github.com/vitalets/playwright-bdd). To enable it, you'll need to adjust your [fixture](https://vitalets.github.io/playwright-bdd/#/getting-started/add-fixtures) file to compose the Playwright BDD API with Chromatic via the [`mergeTests`](https://playwright.dev/docs/test-fixtures#combine-custom-fixtures-from-multiple-modules) function.
+
+```ts title="features/steps/fixtures.ts"
+import { test as chromaticTest } from "@chromatic-com/playwright";
+
+import { test as base, createBdd } from "playwright-bdd";
+
+import { mergeTests } from "@playwright/test";
+
+const FIXTURES = {
+  // Custom fixtures go here
+} as const;
+
+export const test = mergeTests(chromaticTest, base).extend<typeof FIXTURES>(
+  FIXTURES,
+);
+
+export const { Given, When, Then } = createBdd(test);
+```
+
+## Configure Playwright BDD with Chromatic
+
+If you need to include any of the available [configuration options](/docs/playwright/configure/) supported by Chromatic in your BDD tests, you'll need to provide a custom tag to the feature file and adjust your fixture file to override the required option as needed.
+
+<Tabs>
+  <TabItem label="feature">
+    ```plaintext title="features/Homepage.feature"
+    @noAutoSnapshot
+    Feature: Homepage
+
+      Scenario: Homepage loads
+        Given I am on the homepage
+        Then I see the title "Welcome"
+    ```
+
+  </TabItem>
+    <TabItem label="steps">
+    ```ts title="features/steps/fixtures.ts"
+    import { test as chromaticTest } from "@chromatic-com/playwright";
+
+    import { test as base, createBdd } from "playwright-bdd";
+
+    import { mergeTests } from "@playwright/test";
+
+    export const test = mergeTests(chromaticTest, base).extend({
+      disableAutoSnapshot: async ({ $tags }, use) => {
+        await use($tags.includes('@noAutoSnapshot'));
+      },
+      // Add additional options here
+    });
+
+    export const { Given, When, Then } = createBdd(test);
+    ```
+
+  </TabItem>
+</Tabs>
+
+## Enabling targeted snapshots with BDD
+
+To enable [targeted snapshots](/docs/playwright/targeted-snapshots) with BDD, adjust your test steps file to use the `$testInfo` fixture to pass the test information to the `takeSnapshot` function allowing you to take a snapshot of the page at a specific point in the test.
+
+```ts title="features/steps/Homepage.steps.ts"
+import { expect, takeSnapshot } from "@chromatic-com/playwright";
+
+import { Given, Then } from "./fixtures";
+
+Given("I am on the homepage", async ({ page }) => {
+  await page.goto("/");
+});
+
+Then("I see the title {string}", async ({ page }, keyword: string) => {
+  await expect(page).toHaveTitle(new RegExp(keyword));
+  await takeSnapshot(page, "Page Loaded", $testInfo);
+});
+```


### PR DESCRIPTION
This pull request updated the documentation to provide context on BDD testing with Playwright.

What was done:
- Added a new FAQ entry with instructions/examples on how to configure it
- Added a new section to the FAQ
- Added a small entry to the troubleshooting section to mention how to set up custom fixtures with Playwright

I intentionally left the configuration and usage in a FAQ entry temporarily to provide minimal guidance on how to do it and avoid extending the existing documentation, as a small margin of users might need this feature. If we see a growing demand for this feature, we can consider adding a dedicated section to the documentation.