### PR TITLE
add flag to E2E docs and delete typo

### DIFF
--- a/src/content/playwright/configure.mdx
+++ b/src/content/playwright/configure.mdx
@@ -68,6 +68,7 @@ These options control how the Chromatic archive fixture behaves.
 | Option                   | Type            | Description                                                                                                                                                                          |
 | ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `disableAutoSnapshot`    | `boolean`       | When `true`, it will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.                                                     |
+| `cropToViewport     `    | `boolean`       | When `true`, the snapshot will be clipped to viewport.height.                                                                                                                        |
 | `resourceArchiveTimeout` | `number`        | Maximum amount of time each test will wait for the network to be idle while archiving resources.                                                                                     |
 | `assetDomains`           | `array[string]` | A list of domains external to the test location that you want Chromatic to also capture assets from, e.g., <code style="display: inline;">['other-domain.com','our-cdn.com']</code>. |
 

--- a/src/content/playwright/configure.mdx
+++ b/src/content/playwright/configure.mdx
@@ -68,7 +68,7 @@ These options control how the Chromatic archive fixture behaves.
 | Option                   | Type            | Description                                                                                                                                                                          |
 | ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `disableAutoSnapshot`    | `boolean`       | When `true`, it will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.                                                     |
-| `cropToViewport     `    | `boolean`       | When `true`, the snapshot will be clipped to the height of the [viewport](/docs/viewports#playwright).                                                                                                                        |
+| `cropToViewport     `    | `boolean`       | When `true`, the snapshot will be clipped to the height of the [viewport](/docs/viewports#playwright).                                                                               |
 | `resourceArchiveTimeout` | `number`        | Maximum amount of time each test will wait for the network to be idle while archiving resources.                                                                                     |
 | `assetDomains`           | `array[string]` | A list of domains external to the test location that you want Chromatic to also capture assets from, e.g., <code style="display: inline;">['other-domain.com','our-cdn.com']</code>. |
 

--- a/src/content/playwright/configure.mdx
+++ b/src/content/playwright/configure.mdx
@@ -68,7 +68,7 @@ These options control how the Chromatic archive fixture behaves.
 | Option                   | Type            | Description                                                                                                                                                                          |
 | ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `disableAutoSnapshot`    | `boolean`       | When `true`, it will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.                                                     |
-| `cropToViewport     `    | `boolean`       | When `true`, the snapshot will be clipped to viewport.height.                                                                                                                        |
+| `cropToViewport     `    | `boolean`       | When `true`, the snapshot will be clipped to the height of the [viewport](/docs/viewports#playwright).                                                                                                                        |
 | `resourceArchiveTimeout` | `number`        | Maximum amount of time each test will wait for the network to be idle while archiving resources.                                                                                     |
 | `assetDomains`           | `array[string]` | A list of domains external to the test location that you want Chromatic to also capture assets from, e.g., <code style="display: inline;">['other-domain.com','our-cdn.com']</code>. |
 

--- a/src/content/troubleshooting/faq/skip-running-builds.mdx
+++ b/src/content/troubleshooting/faq/skip-running-builds.mdx
@@ -12,4 +12,4 @@ Skipping Chromatic builds on the `main` branch can lead to inaccurate visual com
 
 On the contrary, some users run builds only on the `main` branch after making changes on feature branches. This way the baseline on the `main` branch always compares against the new set of changes merged into it.
 
-When builds are skipped on `main`, each feature branch develops independently, with baselines diverging over time. This leads to more diffs because multiple independent changes accumulate before being reconciled. s
+When builds are skipped on `main`, each feature branch develops independently, with baselines diverging over time. This leads to more diffs because multiple independent changes accumulate before being reconciled.


### PR DESCRIPTION
added flag as discussed here: https://linear.app/chromaui/issue/CAP-2832/viewport-not-being-set-on-capture-3-stories-fail