### PR TITLE
Adds instructions for configuring custom wildcard subdomain

### DIFF
--- a/src/content/collaborate/permalinks.mdx
+++ b/src/content/collaborate/permalinks.mdx
@@ -96,6 +96,16 @@ A custom domain gives you a memorable URL to share with stakeholders and teammat
 </details>
 
 <details>
+<summary><b>How to setup a custom wildcard subdomain</b></summary>
+
+1. Go to the DNS management interface provided by your domain registrar or web hosting provider. Find the section where you can add DNS records.
+2. Add a CNAME record for the subdomain you would like to use, such as `*.storybook.example.com`, then enter `domains.chromatic.com` as the value.
+3. Back in Chromatic, enter the full domain name you’d like to use and choose a target branch. The domain will link to the most recent build on that branch.
+4. If you've setup a custom wildcard subdomain for another project, get in touch and ask for the domain to be whitelisted, in order to complete the configuration.
+
+</details>
+
+<details>
 <summary><b>My domain remains in the "Issuing certificate" state</b></summary>
 
 Your DNS may be configured with [CAA records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization) that only allow certain authorities to issue certificates for your domain names. The Chromatic custom domain relies on Let's Encrypt and ZeroSSL (either one may be used). In order to allow Let's Encrypt or ZeroSSL to issue a certificate for your Chromatic custom domain, add a `CAA` record for `letsencrypt.org` and `sectigo.com`. For example:

--- a/src/content/collaborate/permalinks.mdx
+++ b/src/content/collaborate/permalinks.mdx
@@ -87,12 +87,6 @@ A custom domain gives you a memorable URL to share with stakeholders and teammat
 3. Add a **TXT** record for the root domain and set `apex=domains.chromatic.com` as its value.
 4. Back in Chromatic, enter the full domain name you’d like to use and choose a target branch. The domain will link to the most recent build on that branch.
 
-<img
-  src={permalinksCustomDomain.src}
-  alt="permalinks custom domain"
-  style="width: 400px; display:block; margin: 0 auto;"
-/>
-
 </details>
 
 <details>


### PR DESCRIPTION
Some customers don't want to configure DNS records for a custom subdomain for every Storybook. This adds instructions for configuring a wildcard subdomain, to reduce manual effort on their end.

Caveat: this offloads that manual effort to support, who will have to whitelist each subsequent subdomain, so may need to create a Guru for that separately.

This also removes the custom subdomain screenshot from the apex domain section, as that may be a little confusing. In a future effort should create new screenshots for that and this section.