### PR TITLE
Add FAQ for Figma in Chromatic question about design tokens

### DIFF
--- a/src/content/troubleshooting/faq.mdx
+++ b/src/content/troubleshooting/faq.mdx
@@ -90,6 +90,16 @@ If you have a question not covered in our documentation, contact us via our in-a
   ))}
 </ul>
 
+## Figma in Chromatic
+
+<ul class="faq-section-toc">
+  {props.groupedFAQs.figmaInChromatic.map((faq) => (
+    <li>
+      <a href={`/docs/${faq.slug}`}>{faq.title}</a>
+    </li>
+  ))}
+</ul>
+
 ## Compatibility
 
 <ul class="faq-section-toc">

--- a/src/content/troubleshooting/faq/figma-in-chromatic-tokens-in-designs-tab.mdx
+++ b/src/content/troubleshooting/faq/figma-in-chromatic-tokens-in-designs-tab.mdx
@@ -1,0 +1,10 @@
+---
+layout: "../../../layouts/FAQLayout.astro"
+sidebar: { hide: true }
+title: Does Figma in Chromatic display the name or value of design tokens?
+section: figmaInChromatic
+---
+
+# Does Figma in Chromatic display the name or value of design tokens?
+
+Chromatic will display the _value_ of a design token within the Designs tab of the component library. This helps developers easily reference styles set by your design tokens in Figma.


### PR DESCRIPTION
Adding a quick question to the FAQs that was generated from a sales prospect.  Quick and simple add.  For reference, I did confirm this in `mealdrop-demo` on the `RestaurantCard` component.  Input is welcome!