### PR TITLE
Add TurboSnap guides

### DIFF
--- a/src/content/guides/turbosnap-best-practices.md
+++ b/src/content/guides/turbosnap-best-practices.md
@@ -1,0 +1,181 @@
+---
+layout: "../../layouts/Layout.astro"
+title: TurboSnap Configuration Best Practices
+description: Learn TurboSnap configuration best practices to optimize your builds for faster visual testing
+sidebar: { order: 10, label: "Configuring TurboSnap" }
+---
+
+# TurboSnap Configuration Best Practices: Tips for Faster Visual Testing
+
+Most everyone agrees it's important to test your UI, but it's even more important to make sure you're testing the _right parts_ of your UI at the _right time_. Meet TurboSnap: one of Chromatic's most powerful tools for accelerating visual testing in CI. By using your git history and dependency graph to intelligently detect what's changed in your Storybook project, it helps Chromatic better test the components impacted by your changes—saving you time and CI resources while keeping your tests valuable.
+
+Whether you're working in a single-project repository or have a more complex setup (such as a monorepo), following best practices ensures TurboSnap works efficiently to help surface _meaningful_ visual regressions. Here are some essential tips to keep your TurboSnap running fast, reliably, and accurately.
+
+## Confirm TurboSnap is enabled
+
+Once you've met the [prerequisites](/docs/turbosnap/setup#prerequisites) and started using TurboSnap, it should show as enabled when you visit the "Manage" page of your project. TurboSnap is enabled through the `onlyChanged` option. You can make sure it's enabled for your builds by verifying it's listed within your Chromatic script:
+
+```json
+// package.json
+{
+	"scripts": {
+		"chromatic": "chromatic --only-changed
+	}
+}
+```
+
+If you have a Chromatic configuration file (ex. `chromatic.config.json`), check the file to make sure `onlyChanged` is set to `true`:
+
+```json
+// chromatic.config.json
+{
+  "$schema": "https://www.chromatic.com/config-file.schema.json",
+  "projectId": "Project:...",
+  "onlyChanged": true
+}
+```
+
+Alternatively, it may be in your CI workflow directly:
+
+```yaml
+# .github/workflows/chromatic.yml
+
+jobs:
+  chromatic:
+    steps:
+      # ... other steps
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true # 👈 Required option to enable TurboSnap
+```
+
+## Use accurate directory configuration
+
+If your Storybook config or preview files don't live in the default `./.storybook` location, you'll need to explicitly tell Chromatic where to find them. Whether in a single-project repo or a monorepo, ensuring your directory configuration is accurate can prevent TurboSnap from tracing unnecessary files.
+
+- `storybookBaseDir` sets the root for dependency tracing (what source files are considered part of the Storybook project)
+- `storybookConfigDir` tells Chromatic where to find your Storybook configuration (the path where your `main.js|ts` and `preview.js|ts` live)
+
+If your directories are not properly configured, changes to unrelated files—like your root `package.json` or backend utilities—can trigger full rebuilds.
+
+<div class="aside">
+
+✨ Use the TurboSnap Helper to set your config!
+Run `npx @chromatic-com/turbosnap-helper` from the root of your repo to have the helper provide you with the accurate directories and even automatically update your config file—no more guess work!
+
+</div>
+
+## Avoid excessive dynamic imports
+
+Dynamic imports (`import()` or `require()` with variables or conditions) inside your stories, decorators, preview file, or any of the files they import can break the chain TurboSnap relies on to determine which stories are affected, resulting in missed visual changes or unexpected rebuilds. To help ensure full traceability, consider reducing dynamic imports. If the behavior is _essential_, move the logic into story-level decorators or within the component and avoid dynamic behavior in the preview file.
+
+When it's possible, convert dynamic imports to static imports:
+❌ `const ThemeProvider = require('../themes/default/ThemeProvider');`
+✅ `import { ThemeProvider } from '../themes/default/ThemeProvider';`
+
+## Mind your package control files
+
+TurboSnap relies on lockfiles to get actual version numbers rather than semver ranges to attempt to determine an exact set of changed dependencies for more accurate tracing. If your lockfile is missing or out of sync with `package.json`, this prevents TurboSnap from being able to compute the changes and results in a full rebuild.
+
+📦 Package file tips:
+
+- Make sure you have a valid lockfile checked in and that it's not out of sync with your `package.json`.
+- Avoid unnecessary version bumps in unrelated dependencies.
+- Help reduce noise in lockfile changes by using exact versions.
+- If you're using multiple `package.json` files, only the one associated with the Storybook project should typically affect rebuilds. Excessive rebuilds from `package.json` files outside your project can be reduced by ensuring you scope TurboSnap with the correct `storybookBaseDir`.
+
+## Optimize shared configs and theming
+
+Your Storybook preview file—where you define global decorators, parameters, and theming—is one of the most sensitive files for TurboSnap rebuilds. Why? _Any change_ to the file _or anything it imports_ can impact any story in the project, even if only one component was affected. This means changes to theme object definitions, global decorators, context providers, mock setups, and global parameters will result in an _expected_ full rebuild.
+
+While you **can’t avoid full rebuilds** when changing anything imported by `preview.js|ts` (or changing the file itself), here are some best practices to reduce the impact of `preview.js|ts` changes:
+
+- Minimize imports in your preview file. Avoid importing large libraries or full theme objects, and move large objects (like your full theme config) to separate files that don't change often.
+- Use stable, versioned theme objects. If your project has a design system or uses a component library with theming, import the theme object from a package or file that rarely changes. Importing the theme from a package means changes to the theme require a package release, encouraging discipline and reducing change noise.
+- Split decorators and providers by scope. If all stories don't need the same decorators, consider moving the logic into story-level decorators when feasible.
+
+## Catch changes that don't pass through your builder with `externals`
+
+TurboSnap relies on what your bundler processes, not just what's in the codebase. Making sure impactful files processed externally to your bundler trigger tests is a critical, but often overlooked part of ensuring TurboSnap works correctly and efficiently. It also keeps you from accidentally introducing regressions that could have been caught during visual testing. That's where the `externals` option comes in: it tells TurboSnap to manually watch the specified files or globs for changes, and triggers a rebuild when they change.
+
+Follow these tips to help keep your testing meaningful:
+
+- Be selective when using wild glob patterns unless you've audited all files that match the pattern. Having too many files listed in `externals` can lead to noisy or frequent rebuilds.
+- Make sure the paths you specify are relative to your repository root (which may not be your project root).
+- Ensure the files are tracked in version control. If the file is ignored by `.gitignore`, it won't trigger a rebuild even if it's listed in `externals`.
+
+## Trace what matters, untrace what doesn't, and scope when possible
+
+TurboSnap works by tracing all files that a story depends on, starting from that story's code and walking the import graph. You may find yourself in a situation where some files or folders are:
+
+- frequently updated
+- causing widespread rebuilds when changed
+- not truly impactful to story behavior
+
+In these cases, you can tell TurboSnap to exclude paths from being traced using the `untraced` option. You can safely untrace files that:
+
+- Don't affect the rendering or logic of your components or stories.
+- Are never imported (directly or indirectly) by your stories.
+- Exist solely for documentation, CI scripts, metadata, or non-runtime assets.
+
+❌ There are times where it's dangerous to untrace as it compromises your test coverage. You should avoid adding any files to `untraced` that:
+
+- Are imported by story files, component files, or decorators.
+- Contain theme definitions, configuration, or wrapper logic.
+- Affect how components are rendered—whether directly or indirectly.
+
+If a file or folder is frequently updated and has a broad but legitimate impact on your stories, consider scoping it into a dedicated package or Storybook project to reduce blast radius and increase control. This allows TurboSnap to trace only stories affected by the package, which can be tested through Storybook and Chromatic in isolation. Consider these basic guidelines for when to split:
+
+- Theme file changing daily? Move it to it's own package and project.
+- Global wrapper being used across stories? Extract and import only where needed.
+- Have a provider that affects all stories? Modularize and apply via story-level decorators if possible.
+- Preview file importing volatile code? Move it out of preview and apply it in stories or wrappers to keep preview stable.
+
+## Use the `preview-stats.json` to analyze a file's blast radius
+
+If you're unsure why a change to a file caused a full rebuild, analyzing your `preview-stats.json` file can help you trace the changes in your dependency graph. This gives you a better visualization of the rebuild scope and helps you determine which stories are affected by your changes. The file is generated locally during Storybook builds, so you can easily inspect it to debug before sending anything through CI.
+
+Chromatic provides a [`trace` utility](/docs/turbosnap/troubleshooting#why-are-no-changes-being-detected) that reads your `preview-stats.json` file to trace changed file paths to their dependent story files. This can help you determine:
+
+- Whether a small change to a theme file will trigger rebuilds in all stories.
+- Whether changes to another package will impact your stories.
+- The actual dependency footprint or blast radius of a given file.
+
+## How to know what to expect from performance
+
+With proper TurboSnap configuration, you should expect around 80-90% of your Chromatic builds to skip a full rebuild and test only what's changed. For large projects, this often translates to hundreds of files skipped per build, saving both time and snapshot review overhead. If you're still seeing 50% or more of your builds trigger a full rebuild of all stories, it's a sign that your configuration may need tuning or you have shared code that's being modified too often.
+
+| Optimization level   | Example                                                                                        | Expected full rebuilds (%) |
+| -------------------- | ---------------------------------------------------------------------------------------------- | -------------------------- |
+| No optimization      | default config, shared preview file, barrel files, dynamic imports                             | **~60-100%**               |
+| Partial optimization | baseDir set but noisy preview file                                                             | **~30-60%**                |
+| Well-optimized       | scoped preview file, proper externals, modular stories                                         | **5-25%**                  |
+| Gold standard        | monorepo with isolated apps, per-package SB projects, clean preview files, optimized externals | **1-5%**                   |
+
+TurboSnap can help reduce build time and snapshot volume substantially, but those gains _don't come automatically_. It's not just a feature you toggle on—it's an advanced feature that depends on your setup and proper configuration.
+
+## Conclusion
+
+TurboSnap is designed to help your builds be fast out of the box, but small configuration decisions can make a big difference in performance. Ultimately, performance is your responsibility, but we're here to give you the tools to help configure TurboSnap efficiently. Your actual results with TurboSnap depend on how your team:
+
+- Structures shared configuration
+- Handles themes and decorators
+- Writes and organizes stories
+- Audits and maintains the dependency graph
+
+By following best practices like:
+
+- Scoping changes to only what needs to change
+- Modularizing global code
+- Declaring externals for non-bundled assets
+- Auditing your `preview-stats.json` file with the `trace` utility
+  ...you can achieve consistent, super-fast builds with minimal overhead and without compromising your test coverage.
+
+## Next: Optimizing TurboSnap for Monorepos
+
+If you're working out of a monorepo or with a large, complex project, you can easily find yourself running the wrong tests at the wrong time. Learn practical strategies to help manage your dependencies and keep your tests meaningful!
+
+<a class="btn primary round" href="/docs/turbosnap-for-monorepos">Read next chapter</a>

--- a/src/content/guides/turbosnap-best-practices.md
+++ b/src/content/guides/turbosnap-best-practices.md
@@ -111,7 +111,7 @@ If you find yourself needing more fine-tuned control over your git environment v
     CHROMATIC_SLUG: ${{ github.repository }}
 ```
 
-<div class="aside>
+<div class="aside">
 
 These values match what you'd want TurboSnap and Chromatic to see, but _only if the correct code is checked out_. If you're not using `ref` to ensure the correct commit is checked out, setting your git environment variables _will not help_. Without `ref`, your env variables could describle one commit, while the git workspace contains another, causing TurboSnap to have unpredictable results.
 

--- a/src/content/guides/turbosnap-for-monorepos.md
+++ b/src/content/guides/turbosnap-for-monorepos.md
@@ -15,8 +15,8 @@ In this guide, we’ll break down practical strategies for managing `dependencie
 
 <div class="aside">
 
-🎉 **TurboSnap Helper has leveled up!**
-Configure faster, optimize smarter, and cut down your rebuilds—now with monorepo support and new analysis features! [Click here to read more about the TurboSnap Helper utility.](/docs/turbosnap/setup#update-your-configuration-using-turbosnap-helper)
+🎉 **Try TurboSnap Helper!**
+Run our helper utility to accurately configure TurboSnap, even in monorepos—no more guess work! [Read how you can run the utility and get instant help with your config.](/docs/turbosnap/setup#update-your-configuration-using-turbosnap-helper)
 
 </div>
 

--- a/src/content/guides/turbosnap-for-monorepos.md
+++ b/src/content/guides/turbosnap-for-monorepos.md
@@ -1,0 +1,105 @@
+---
+layout: "../../layouts/Layout.astro"
+title: Optimizing TurboSnap for Monorepos
+description: Learn tips to optimize your TurboSnap configuration when working in a monorepo
+sidebar: { order: 11, label: "TurboSnap for monorepos" }
+---
+
+# Optimizing TurboSnap for Monorepos: Smart Dependency Management Tips
+
+For large teams working out of a monorepo, meaningful tests are vital to testing what matters, when it matters. When you're shipping changes across dozens of packages, it's not just about running _faster_ tests—it's about running the _right_ ones. If you're constantly triggering full rebuilds or skipping coverage on affected components, it becomes impossible to trust the results.
+
+That’s where TurboSnap comes in. It’s one of the most powerful tools in Chromatic’s toolbox, helping teams test faster by only running visual tests on what’s actually changed. But to really take advantage of it—especially in a monorepo—you need to structure your dependencies carefully. One misplaced import or a poorly scoped `package.json` change can derail your whole setup.
+
+In this guide, we’ll break down practical strategies for managing `dependencies`, `devDependencies`, dynamic imports, and `package.json` files in a way that keeps your TurboSnap builds snappy _and_ your coverage meaningful.
+
+<div class="aside">
+
+🎉 **TurboSnap Helper has leveled up!**
+Configure faster, optimize smarter, and cut down your rebuilds—now with monorepo support and new analysis features! [Click here to read more about the TurboSnap Helper utility.](/docs/turbosnap/setup#update-your-configuration-using-turbosnap-helper)
+
+</div>
+
+## Prefer importing from built packages over `src`
+
+Do you have components that are part of a design system or shared library? If so:
+
+- import them from the built package (ex. from `node_modules/@your-org/ui`)
+- avoid importing directly from `src` unless you _intend_ for the story to re-test when that imported file changes
+
+Why make this consideration? TurboSnap uses git tracking to detect changes. Built packages are usually excluded from git (ex. `dist` is in `.gitignore`), so they won't trigger unnecessary story rebuilds unless the _consumer_ has actually rebuilt and re-imported them.
+
+Some teams intentionally import from `src` for faster development. If this is the case, consider the tradeoffs and whether _faster development_ or _fewer unnecessary tests_ are more important to the team.
+
+## Use project-specific lockfiles carefully in monorepos
+
+If you're using tools like Nx or pnpm workspaces with project-specific lockfiles, then know that changes to a `package.json` (without a valid lockfile) or to lockfiles may trigger broad rebuilds.
+
+If you're using Nx, you can use [`implicitDependencies`](https://nx.dev/reference/project-configuration#implicitdependencies) in your Nx project config to limit which story packages are affected when a package file changes. While TurboSnap doesn't have native awareness of `affected`, using `nx affected` (or equivalent) can help inform whether you need to rebuild, leading to more meaningful tests and fewer unnecessary full rebuilds.
+
+## Avoid changes to shared or root-level package files unless necessary
+
+Changing dependencies at the root or in shared `package.json` files will often trigger TurboSnap to retest all stories. When possible, limit root-level `package.json` changes to toolchains or devDeps. Keep shared runtime dependencies in leaf packages (a standalone UI component or package that isn’t imported by any other internal packages) so they're not a dependency for any other package.
+
+## Understand the role of `dependencies` vs `devDependencies`
+
+TurboSnap uses your bundler's dependency graph (Webpack, Vite, Rsbuild) to determine which stories are affected by changes. That means changes to runtime dependencies (`dependencies`) can ripple into the UI, while development-only tools (`devDependencies`) often don’t—unless they’re used in your Storybook config or components.
+
+Best Practices:
+
+- Keep runtime dependencies (like `react`, `styled-components`, `axios`) in `dependencies`.
+- Use `devDependencies` for build tools (ex. `vite`, `eslint`, `typescript`, Storybook addons).
+- Avoid using dev-only packages in `preview.ts` or inside components—if they’re needed at runtime, they should be in `dependencies`.
+
+## Group and isolate high-churn utilities
+
+If you have shared utility functions that frequently change, you may see more retests than expected. Every change to those utility files will cascade to every component that imports from the package, which can trigger TurboSnap to retest all related stories.
+
+Instead, isolate those utilities into a clearly scoped package and avoid re-exporting them through your UI library or core package. Import the utilities in your app code and not your shared design system unless they're directly UI-related.
+
+## Avoid dynamic imports in preview files
+
+Dynamic imports can interfere with TurboSnap's static analysis of your dependency graph. Since the paths are resolved at runtime, it's best to avoid them in story files unless you have a clear reason to use them, as TurboSnap may struggle to properly trace changes. If you're using dynamic imports in your preview file, this can trigger unexpected rebuilds. Always use direct imports in your preview file and shared utility files to ensure full traceability.
+
+Why does this happen? Dynamic imports break the chain TurboSnap relies on to determine which stories are affected. This can lead TurboSnap to either under-test or over-test. Using direct imports ensures the dependency graph can follow the file and see which components were affected, resulting in TurboSnap only retesting stories that directly or indirectly depend on that file.
+
+## Avoid excessive wrapper indirection
+
+You **can’t avoid full rebuilds** when changing anything imported by `preview.ts`, but you _can reduce the blast radius of changes_ and improve your team’s visibility by avoiding excessive wrapper indirection.
+
+Excessive wrapper indirection may look like `withTheme()` wrapping stories with a provider theme, then being imported by `withGlobalProvider()` which wraps the stories in locale. Flattening this structure so `withTheme()` and `withLocale()` are individually defined makes it easier to see which dependencies are responsible when retesting. It also lets you bypass the preview file for some stories by importing the providers directly in specific stories, which would ensure only those files are tested when changes are made to the providers.
+
+When possible, use direct imports and consider moving stable wrappers into `preview.ts`. If you're using frequently changing wrappers or features, try to keep them limited to **individual stories** to minimize their impact.
+
+## Document your dependency graph
+
+Larger teams working out of a monorepo can benefit from clearly identifying which packages depend on which. Tools like [Nx Graph](https://nx.dev/features/explore-graph) (or similar) can help your team visualize your dependency graph and avoid unintentional coupling between packages.
+
+## Monitor `changedPackageFiles` in Chromatic builds
+
+If you notice frequent rebuilds due to changes in package files, keep an eye on Chromatic's CLI output for `changedPackageFiles`. TurboSnap will list all package files that triggered a rebuild. Investigate whether the changes are necessary, if there are opportunities to better isolate your packages, or if you should consider using `--untraced` to ignore the packages.
+
+### Use caution when marking package files as `--untraced`
+
+Monorepos often include many `package.json` files, and some may trigger rebuilds unnecessarily.
+
+✅ **It’s safe to mark `package.json` as `--untraced` when:**
+
+- The package is not consumed by Storybook or preview files
+- The file does not affect the runtime or build output (ex. purely backend or tooling packages)
+- You use a shared lockfile (`pnpm-lock.yaml`, `yarn.lock`), ensuring consistent resolution
+- You rely on `Nx affected` or similar tooling
+
+❌ **Do not untrace if:**
+
+- The package includes components, themes, or utilities used in stories
+- The package influences global configuration or decorators in `preview.js|ts`
+- Changes to it could result in different builds or runtime behavior
+
+## Conclusion
+
+Smart dependency management in a monorepo can drastically improve TurboSnap performance and confidence, making it easier and faster to test changes before pushing them to production. By being intentional with how you structure `dependencies`, avoiding dynamic imports in shared config, and tracing changes clearly, you’ll strike the perfect balance between speed and reliability in your visual testing pipeline.
+
+Ready to optimize your builds? Start by auditing your most frequently rebuilt packages!
+
+Looking to get more details on dependency tracing with TurboSnap? Head over to our docs to read more about [TurboSnap dependency tracing](/docs/turbosnap/dependency-tracing/).

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -58,6 +58,16 @@ steps:
       onlyChanged: true
 ```
 
+TurboSnap can also be enabled through your `chromatic.config.json` file:
+
+```json
+{
+  "$schema": "https://www.chromatic.com/config-file.schema.json",
+  "projectId": "Project:...",
+  "onlyChanged": true
+}
+```
+
 You may need additional config in the following situations:
 
 - You're using `--storybook-build-dir` or `-d` to let Chromatic use a prebuilt Storybook
@@ -67,6 +77,43 @@ You may need additional config in the following situations:
 - You want to enable or disable TurboSnap for specific branches
 
 Jump to the [recipes](#recipes) section for more information.
+
+### Update your configuration using TurboSnap Helper
+
+Having TurboSnap properly configured is essential when trying to optimize build performance. If you're working in a monorepo, or even just a large project with a complex setup, setting up TurboSnap efficiently can feel overwhelming. That's where the TurboSnap helper comes in! We've introduced the `@chromatic-com/turbosnap-helper` CLI utility to simplify the process of managing your configuration.
+
+The TurboSnap Helper utility is designed to assist with properly configuring TurboSnap for Chromatic. It's especially helpful in monorepos, where managing directories, static assets, and build optimizations across multiple projects can get tricky.
+
+Run the utility from the root of your repo using:
+
+```sh
+npx @chromatic-com/turbosnap-helper
+```
+
+<div class="aside">
+
+❓ **Why run the utility from the repo root rather than the project root?**
+TurboSnap Helper has been updated to support monorepos! By starting from the root, it can scan across all of your projects, so you're not accidentally missing assets or settings that could cause full rebuilds. If you run the utility from your project root, not a problem! The utility will still work just fine.
+
+</div>
+
+#### Helper modes to give you a deeper analysis
+
+The utility now features three modes you can run:
+
+- `init` (default) - walks you through creating or updating your TurboSnap config
+- `analyze` - reviews your story and component files for dynamic imports
+- `preview` - analyzes your preview file for shared dependencies that could cause full rebuilds
+
+Running `init` mode not only prints out configuration options in the CLI, but **automatically adds the correct config options** to your Chromatic config file. We've enhanced the utility to take it beyond directory config help and introduced static asset detection, allowing you to easily add static assets to your `externals` config to ensure you don't miss changes. Don't have an existing Chromatic config file? No worries—the utility will create one for you!
+
+To help further optimize your builds, the utility has an `analyze` mode that scans both story and components files to detect and surface dynamic imports. Dynamic imports are a hidden culprit for confusing TurboSnap behavior that can result in missed regressions or unnecessary rebuilds. `analyze` mode helps you track them down early.
+
+And last is the `preview` mode, which displays an analysis of your Storybook preview file. Use the analysis to help keep your preview file clean and efficient, as a messy preview file can turn small changes into **full rebuilds**. The analysis provides:
+
+- Warnings if your import count is too high (the higher the imports, the more likely you'll see frequent rebuilds)
+- Lists shared wrappers/themes that could trigger global rebuilds
+- Prints any dynamic imports inside your preview file
 
 ### Verify that TurboSnap is working
 


### PR DESCRIPTION
Adding the following:
- `@chromatic-com/turbosnap-helper` information added to `setup-turbosnap.mdx`; nested this under "Configure"
- TurboSnap guide for monorepos
- TurboSnap best practice guide 

Please feel free to make adjustments as needed.  In addition to the monorepo content previously brought up, I've added general best practices for TurboSnap to help cover initial setup essentials.  Jeff asked if we could include rebuild expectations (included in `turbosnap-best-practices.md`), and the figures provided were based on empirical observation.  Please feel free to adjust if there are more accurate figures!