### PR TITLE
Docs: Minor link fixes

### DIFF
--- a/src/content/guides/in-pull-request.md
+++ b/src/content/guides/in-pull-request.md
@@ -95,7 +95,6 @@ You can change whether each check is required separately.
 You finished touring all the ways Chromatic contributes to your UI development workflow. We look forward to the incredible UIs you’ll build. Continue exploring with our most popular guides and articles:
 
 - [Intro to Storybook](https://storybook.js.org/tutorials/intro-to-storybook/) is the essential guide to learning Storybook.
-- [Design Systems for Developers](https://storybook.js.org/tutorials/design-systems-for-developers/) shares how to build production infrastructure for design systems.
 - [Visual Testing Handbook](https://storybook.js.org/tutorials/visual-testing-handbook/) details how professional frontend teams visual test with Storybook.
 - [Component-Driven Development](https://www.componentdriven.org/) is a "bottoms up" process for building modular UIs starting from components and ending with screens.
 - [UI Testing Handbook](https://storybook.js.org/tutorials/ui-testing-handbook/) highlights testing strategies used by scaled front-end teams

--- a/src/content/modes/modes.mdx
+++ b/src/content/modes/modes.mdx
@@ -428,7 +428,7 @@ If you rename the mode, a new snapshot baseline will be created based on the new
 <details>
 <summary>Which addons are supported?</summary>
 
-Any Storybook addon that uses [globals](https://storybook.js.org/docs/essentials/toolbars-and-globals#globals). For example:  [@storybookjs/addon-themes](https://storybook.js.org/addons/@storybook/addon-themes), [@storybookjs/addon-viewport](https://storybook.js.org/addons/@storybook/addon-viewport), [@storybook/addon-backgrounds](https://storybook.js.org/addons/@storybook/addon-backgrounds) and [storybook-i18n](https://storybook.js.org/addons/storybook-i18n).
+Any Storybook addon that uses [globals](https://storybook.js.org/docs/essentials/toolbars-and-globals#globals). For example: [@storybookjs/addon-themes](https://storybook.js.org/addons/@storybook/addon-themes), and [storybook-i18n](https://storybook.js.org/addons/storybook-i18n).
 
 Or if you build a custom decorator that uses addons. For more on custom decorators, see: [Modes with custom decorators](/docs/custom-decorators).
 

--- a/src/content/modes/viewports.mdx
+++ b/src/content/modes/viewports.mdx
@@ -117,9 +117,9 @@ export const MembersOnly = {
 
 When Chromatic captures your story, it will create *two* snapshots on your build, with the browser set at each viewport. These modes will be treated separately, with independent baselines and distinct approvals.
 
-## Combining modes with viewports addon
+## Combining modes with the viewports feature
 
-The Storybook [viewport addon](https://storybook.js.org/docs/essentials/viewport) enables you to adjust the dimensions of the story canvas. Developers use it to verify the responsive behavior of components when building UIs. With modes, you can easily reference the different viewport sizes that you have configured for the addon.
+The Storybook [viewport feature](https://storybook.js.org/docs/essentials/viewport) enables you to adjust the dimensions of the story canvas. Developers use it to verify the responsive behavior of components when building UIs. With modes, you can easily reference the different viewport sizes configured with the feature.
 
 <video autoPlay muted playsInline loop width="600px" class="center">
   <source src="/docs/assets/addon-viewports-optimized.mp4" type="video/mp4" />
@@ -130,7 +130,7 @@ The Storybook [viewport addon](https://storybook.js.org/docs/essentials/viewport
 You start by configuring your desired set of viewports in `.storybook/preview.js`. For example:
 
 <div class="aside">
-  ⚠️&nbsp;&nbsp;While the viewport addon allows you to specify dimensions using
+  ⚠️&nbsp;&nbsp;While the viewport feature allows you to specify dimensions using
   any valid CSS unit (such as px, rem, calc, etc.), Chromatic modes only support
   whole numbers or strings with a "px" suffix.
 </div>
@@ -188,7 +188,7 @@ export const allModes = {
 
 Within Storybook, you have the ability to configure the default viewport for stories at different levels: project, component, or story. This can be done by setting the `parameters.viewport` value. By adjusting this setting, you can control the dimensions of the story canvas when viewing it in the browser using Storybook. Chromatic will respect the `defaultViewport` setting when capturing snapshots.
 
-`defaultViewport` can ve set via a named viewport from the viewport addon:
+`defaultViewport` can be set via a named viewport from the viewport feature:
 
 <Tabs>
   <TabItem label="preview.js">

--- a/src/content/snapshot/troubleshooting-snapshots.md
+++ b/src/content/snapshot/troubleshooting-snapshots.md
@@ -325,7 +325,7 @@ It's essential that your components and stories render in a **consistent** fashi
 
 When using Playwright or Cypress, you can serve static files like fonts, images, and videos through your app server. This ensures that resources load consistently across all snapshots.
 
-For Storybook, use the [staticDirs](https://storybook.js.org/docs/configure/integration/images-and-assets#serving-stae-files-via-storybook-configuration) option to load static files for your stories.
+For Storybook, use the [staticDirs](https://storybook.js.org/docs/configure/integration/images-and-assets#serving-static-files-via-storybook-configuration) option to load static files for your stories.
 
 ## Browser differences between snapshots
 

--- a/src/content/storybook/interactions.md
+++ b/src/content/storybook/interactions.md
@@ -59,7 +59,7 @@ export const InputRange: Story = {
 
 <div class="aside">
 
-Read Storybook's interaction testing [docs](https://storybook.js.org/docs/writing-tests/interaction-testing). Get an API cheatsheet for user events [here](https://storybook.js.org/docs/writing-tests/interaction-testing#api-for-user-events).
+Read Storybook's interaction testing [docs](https://storybook.js.org/docs/writing-tests/interaction-testing).
 
 </div>
 

--- a/src/content/troubleshooting/faq/interaction-test-disabled-with-disablesnapshot.mdx
+++ b/src/content/troubleshooting/faq/interaction-test-disabled-with-disablesnapshot.mdx
@@ -11,4 +11,4 @@ The `disableSnapshot` parameter disables snapshotting and interaction testing fo
 
 ![Confirm interaction test run in the build summary](../../../images/interaction-test-buildsummary-confirm.png)
 
-If you want to run Interaction tests without snapshotting, try setting up the [Storybook test-runner](https://storybook.js.org/docs/writing-tests/interaction-testing#execute-tests-with-the-test-runner) in CI. Note, this involves running your own browser infrastructure. 
+If you want to run Interaction tests without snapshotting, try setting up the [Storybook test-runner](https://storybook.js.org/docs/writing-tests/integrations/test-runner#set-up-ci-to-run-tests) in CI. Note, this involves running your own browser infrastructure. 


### PR DESCRIPTION
With this small pull request some of the links used in the documentation were fixed based on the upcoming Storybook release to prevent 404s and broken link references.

What was done:
- Removed the DSD tutorial as it's no longer available
- Fixed some of the testing links to their proper locations
- Replaced the viewports references from addons to features to align with the terminology


@winkerVSbecks, when you have a moment, can you take a look at this and let me know of any feedback you may have? Also, I'm going to take a pass at the modes section shortly and start aligning the documentation (including snippets) with the new patterns. 