### PR TITLE
Remove requirement for an accepted build

### DIFF
--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -30,7 +30,7 @@ It will build and test stories that may have been affected by the Git changes si
 - Storybook 6.5+
 - Webpack or Vite based project (Vite is natively supported with Storybook 8+ and can be used in earlier versions with the [vite-plugin-turbosnap](https://github.com/IanVS/vite-plugin-turbosnap))
 - Stories correctly [configured](https://storybook.js.org/docs/configure#configure-story-loading) in Storybook's `main.js`
-- 10 successful builds on CI with at least one accepted
+- 10 successful builds on CI
 - For GitHub Actions: run on `push` rather than `pull_request` ([learn more](#github-pull_request-triggers))
 - [UI Tests](/docs/test/#enable) should be enabled
 


### PR DESCRIPTION
Since https://github.com/chromaui/chromatic/pull/9741 we no longer need an accepted build to allow TS