### PR TITLE
TurboSnap best practices sidebar title should match the doc title

### DIFF
--- a/src/content/guides/turbosnap-best-practices.md
+++ b/src/content/guides/turbosnap-best-practices.md
@@ -2,7 +2,7 @@
 layout: "../../layouts/Layout.astro"
 title: TurboSnap best practices
 description: TurboSnap best practices to optimize your builds for faster testing
-sidebar: { order: 10, label: "Configuring TurboSnap" }
+sidebar: { order: 10, label: "TurboSnap best practices" }
 ---
 
 # TurboSnap best practices


### PR DESCRIPTION
TurboSnap best practices sidebar title should match the doc title