### PR TITLE
Docs: Adjust examples

### DIFF
--- a/src/content/collaborate/composition.md
+++ b/src/content/collaborate/composition.md
@@ -21,12 +21,14 @@ Chromatic generates a [permalink](/docs/permalinks) for published Storybooks to 
 
 ### Setup
 
-In your local Storybook, add a `refs` key to [`.storybook/main.js`](https://storybook.js.org/docs/configure#configure-story-rendering). Paste the permalink in the `url` field.
+In your local Storybook, add a `refs` key to [`.storybook/main.js|ts`](https://storybook.js.org/docs/configure#configure-story-rendering). Paste the permalink in the `url` field.
 
-```js
-// .storybook/main.js
+```js title="storybook/main.ts"
+// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+import type { StorybookConfig } from "@storybook/your-framework";
 
-const config = {
+const config: StorybookConfig = {
+  framework: '@storybook/your-framework',
   stories: ["../src/**/*.stories.@(js|jsx|ts|tsx)"],
   refs: {
     // 👇 Upper-case characters not supported in the refs key

--- a/src/content/configuration/ischromatic.md
+++ b/src/content/configuration/ischromatic.md
@@ -11,7 +11,7 @@ The `isChromatic` method allows you to control how your Storybook tests run in t
 
 <div class="aside">
 
-ℹ️  The `isChromatic` helper function is specific to Storybook tests. If you need to control what code is executed in your Playwright or Cypress tests, you can use environment variables or other mechanisms provided by those tools to achieve similar results.
+ℹ️ The `isChromatic` helper function is specific to Storybook tests. If you need to control what code is executed in your Playwright or Cypress tests, you can use environment variables or other mechanisms provided by those tools to achieve similar results.
 
 </div>
 
@@ -44,13 +44,13 @@ import isChromatic from "chromatic/isChromatic";
 
 import { MyComponent } from "./MyComponent";
 
-const meta: Meta<typeof MyComponent> = {
+const meta = {
   component: MyComponent,
   title: "MyComponent",
-};
+} satisfies Meta<typeof MyComponent>;
 
 export default meta;
-type Story = StoryObj<typeof MyComponent>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
@@ -67,7 +67,7 @@ If you're running Storybook tests with version 7.6 or higher, you can also use t
 {
   "scripts": {
     "chromatic": "IS_CHROMATIC=true chromatic"
- }
+  }
 }
 ```
 
@@ -79,13 +79,13 @@ import type { Meta, StoryObj } from "@storybook/your-framework";
 
 import { MyComponent } from "./MyComponent";
 
-const meta: Meta<typeof MyComponent> = {
+const meta = {
   component: MyComponent,
   title: "MyComponent",
-};
+} satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof MyComponent>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
@@ -106,7 +106,6 @@ Under specific circumstances, your components may require different behavior whe
 
 <div class="aside">
 
- 💡 If you're attempting to make code-specific changes in your project with `isChromatic`, the Chromatic package must be installed as a dependency instead of a development dependency.
+💡 If you're attempting to make code-specific changes in your project with `isChromatic`, the Chromatic package must be installed as a dependency instead of a development dependency.
 
 </div>
-

--- a/src/content/cypress/setup.mdx
+++ b/src/content/cypress/setup.mdx
@@ -80,15 +80,13 @@ Install [chromatic](https://www.npmjs.com/package/chromatic) and `@chromatic-com
 
 Add the following to your `cypress/support/e2e.js` file:
 
-```js
-// cypress/support/e2e.js
+```js title="cypress/support/e2e.js"
 import "@chromatic-com/cypress/support";
 ```
 
 Then, install the Chromatic plugin in your `cypress.config.js` file:
 
-```js
-// cypress.config.js
+```js title="cypress.config.js"
 const { defineConfig } = require("cypress");
 const { installPlugin } = require("@chromatic-com/cypress");
 

--- a/src/content/cypress/targeted-snapshots.md
+++ b/src/content/cypress/targeted-snapshots.md
@@ -12,7 +12,7 @@ By default, Chromatic takes a snapshot at the end of every Cypress test, whether
 
 `takeSnapshot` is especially useful for capturing a snapshot of your UI’s appearance when your UI reaches a specific state mid-test:
 
-```js
+```js title="cypress/e2e/Example.cy.js|ts"
 describe("My First Test", () => {
   it("Visits the Kitchen Sink", () => {
     // 👇 Navigate to target page

--- a/src/content/guides/config-with-story-params.md
+++ b/src/content/guides/config-with-story-params.md
@@ -15,20 +15,18 @@ This guide will show you how to configure Chromatic features like [`diffThreshol
 
 Parameters specified at the story level apply to that story only. They are defined in the parameters property of the story (named export):
 
-```ts
-// Button.stories.ts|tsx
-
+```ts title="Button.stories.ts|tsx"
 // Replace your-framework with the framework you are using (e.g., nextjs, vue3-vite)
 import type { Meta, StoryObj } from "@storybook/your-framework";
 
-import { Button } from "./button.component";
+import { Button } from "./Button";
 
-const meta: Meta<typeof Button> = {
+const meta = {
   component: Button,
-};
+} satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof Button>;
+type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
@@ -45,24 +43,22 @@ export const Primary: Story = {
 
 Parameters specified in a CSF file's meta configuration apply to all stories in that file. They are defined in the parameters property of the meta (default export):
 
-```ts
-// Button.stories.ts|tsx
-
+```ts title="Button.stories.ts|tsx"
 // Replace your-framework with the framework you are using (e.g., nextjs, vue3-vite)
 import type { Meta, StoryObj } from "@storybook/your-framework";
 
-import { Button } from "./button.component";
+import { Button } from "./Button";
 
-const meta: Meta<typeof Button> = {
+const meta = {
   component: Button,
   parameters: {
     // Sets the diffThreshold for 0.2 for all stories in this file
     chromatic: { diffThreshold: 0.2 },
   },
-};
+} satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof Button>;
+type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
@@ -82,8 +78,8 @@ export const Secondary: Story = {
 Parameters specified at the project (global) level apply to all stories in your Storybook. They are defined in the parameters property of the default export in your `.storybook/preview.js|ts` file:
 
 ```ts
-// Replace your-renderer with the renderer you are using (e.g., react, vue3)
-import { Preview } from "@storybook/your-renderer";
+// Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite) if you're using Storybook 9, or with the appropriate renderer otherwise.
+import { Preview } from "@storybook/your-framework";
 
 const preview: Preview = {
   parameters: {

--- a/src/content/guides/config-with-story-params.md
+++ b/src/content/guides/config-with-story-params.md
@@ -77,9 +77,9 @@ export const Secondary: Story = {
 
 Parameters specified at the project (global) level apply to all stories in your Storybook. They are defined in the parameters property of the default export in your `.storybook/preview.js|ts` file:
 
-```ts
+```ts title=".storybook/preview.ts"
 // Replace your-framework with the framework you are using (e.g., react-vite, vue3-vite) if you're using Storybook 9, or with the appropriate renderer otherwise.
-import { Preview } from "@storybook/your-framework";
+import type { Preview } from "@storybook/your-framework";
 
 const preview: Preview = {
   parameters: {

--- a/src/content/guides/mock-network-requests.md
+++ b/src/content/guides/mock-network-requests.md
@@ -13,9 +13,7 @@ When testing components or pages that make network requests, it's important to m
 
 Storybook offers [several addons](https://storybook.js.org/addons/tag/api) for mocking APIs (e.g. fetching data from a REST or GraphQL API). We recommend using the [MSW addon](https://storybook.js.org/addons/msw-storybook-addon). Mock Service Worker (MSW) is an API mocking library that uses service workers to capture network requests and provide mocked data in response. The MSW addon integrates this functionality into Storybook. Here’s a basic example:
 
-```tsx
-// DocumentScreen.stories.ts|tsx
-
+```tsx title="DocumentScreen.stories.tsx"
 // Replace your-framework with the name of your framework (e.g. nextjs, vue3-vite)
 import type { Meta, StoryObj } from "@storybook/your-framework";
 
@@ -23,12 +21,12 @@ import { http, HttpResponse, delay } from "msw";
 
 import { DocumentScreen } from "./DocumentScreen";
 
-const meta: Meta<typeof DocumentScreen> = {
+const meta = {
   component: DocumentScreen,
-};
+} satisfies Meta<typeof DocumentScreen>;
 
 export default meta;
-type Story = StoryObj<typeof DocumentScreen>;
+type Story = StoryObj<typeof meta>;
 
 // 👇 The mocked data that will be used in the story
 const mockDocuments = [
@@ -92,7 +90,7 @@ For more details, check out the [Mocking network requests](https://storybook.js.
 
 Playwright allows you to mock network requests, including XHRs and fetch requests. You can also use HAR files to mock multiple network requests made by the page. Check out the [Playwright documentation](https://playwright.dev/docs/mock#mock-api-requests) for more details.
 
-```js
+```js title="tests/DocumentScreen.spec.js|ts"
 test("mocks documents api", async ({ page }) => {
   // Mock the api call before navigating
   await page.route("*/**/api/documents", async (route) => {
@@ -136,7 +134,7 @@ test("mocks documents api", async ({ page }) => {
 
 Cypress allows you to stub API responses with the `cy.intercept()` method, letting you define the body, HTTP status code, headers, and other response characteristics. You can also use `cy.fixture()` to load mock data from a file. For more details, check out the [Cypress documentation](https://docs.cypress.io/guides/guides/network-requests#Stubbing).
 
-```js
+```js title="cypress/e2e/DocumentScreen.cy.js|ts"
 cy.intercept(
   {
     method: "GET", // Route all GET requests

--- a/src/content/interactionTests/interactions.md
+++ b/src/content/interactionTests/interactions.md
@@ -24,21 +24,21 @@ Add a [`play`](https://storybook.js.org/docs/writing-stories/play-function) func
 import type { Meta, StoryObj } from "@storybook/your-framework";
 
 /*
- * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
+ * Replace storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
  * import { userEvent } from "@storybook/testing-library";
  * import { expect } from "@storybook/jest";
  */
-import { userEvent, expect } from "@storybook/test";
+import { userEvent, expect } from "storybook/test";
 
 import { RangeSlider } from "./RangeSlider";
 
-const meta: Meta<typeof RangeSlider> = {
+const meta = {
   component: RangeSlider,
   title: "Library/Charts/RangeSlider",
-};
+} satisfies Meta<typeof RangeSlider>;
 
 export default meta;
-type Story = StoryObj<typeof RangeSlider>;
+type Story = StoryObj<typeof meta>;
 
 export const InputRange: Story = {
   play: async ({ canvas }) => {
@@ -74,24 +74,30 @@ Similarly to `args`, `play()` functions can be [composed](https://storybook.j
 
 There is an important caveat to remember when invoking a `play()` function from another story: it is necessary to pass the _full context_ as an argument to the `play()` function. The below code uses the correct code for this rule, with `canvasContext` being used as context.
 
-```jsx title="MyComponent.stories.jsx|tsx"
+```jsx title="MyComponent.stories.ts|tsx"
+// Adjust this import to match your framework (e.g., nextjs, vue3-vite)
+import type { Meta, StoryObj } from "@storybook/your-framework";
+
 import { MyComponent } from "./MyComponent";
-import { userEvent, waitFor, screen } from "@storybook/testing-library";
+import { screen, userEvent, waitFo  } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 
-export default {
+const meta = {
   component: MyComponent,
   title: "My Component",
-};
+} satisfies Meta<typeof MyComponent>;
 
-export const FirstStory = {
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FirstStory: Story = {
   play: async ({ canvas }) => {
     const dropdownButton = canvas.getByRole("button");
     await userEvent.click(dropdownButton);
   },
 };
 
-export const SecondStory = {
+export const SecondStory: Story = {
   play: async (canvasContext) => {
     const canvas = canvas;
     //  👇 Pass the full context as an argument to the play function:
@@ -102,7 +108,7 @@ export const SecondStory = {
   },
 };
 
-export const ThirdStory = {
+export const ThirdStory: Story = {
   play: async (canvasContext) => {
     //  👇 SecondStory.play will execute the play functions from FirstStory.play since this is part of the SecondStory.play function:
     await SecondStory.play(canvasContext);

--- a/src/content/interactionTests/shadow-dom.md
+++ b/src/content/interactionTests/shadow-dom.md
@@ -15,7 +15,9 @@ With the help of [shadow-dom-testing-library](https://github.com/konnorrogers/sh
 Install `shadow-dom-testing-library` and then in your preview file, inject shadow-aware query methods into the `canvas` object using `beforeEach()`.
 
 ```ts title=".storybook/preview.ts"
-import type { Preview } from "@storybook/web-components";
+// Replace the @storybook/web-components-vite package with @storybook/web-components if you're not using Storybook 9.0
+import type { Preview } from "@storybook/web-components-vite";
+
 import { within as withinShadow } from "shadow-dom-testing-library";
 
 const preview: Preview = {
@@ -24,11 +26,11 @@ const preview: Preview = {
   },
 };
 
-// extend TypeScript types for safety
+// Extend TypeScript types for safety
 export type ShadowQueries = ReturnType<typeof withinShadow>;
 
 declare module "storybook/internal/csf" {
-  // since 8.6
+  // Since 8.6
   interface Canvas extends ShadowQueries {}
 }
 
@@ -41,9 +43,9 @@ This adds methods like `findByShadowRole`, `findAllByShadowRole`, etc., directly
 
 Use shadow root queries directly in your `play()` function, like so:
 
-```tsx
-const Story = {
-  async play({ canvas }) {
+```ts title="Button.stories.ts"
+const Story: Story = {
+  play: async ({ canvas, userEvent }) => {
     const button = await canvas.findByShadowRole("button", { name: /Reset/i });
     await userEvent.click(button);
   },
@@ -56,9 +58,18 @@ Using `shadow-dom-testing-library` provides DOM querying methods that mirror the
 
 Let's say you're testing a Web Component `<checkbox-group>` that renders shadow-root-contained checkboxes.
 
-```tsx title="CheckboxGroup.stories.tsx"
-import { Meta, StoryObj } from "@storybook/web-components";
-import { expect, userEvent } from "@storybook/test";
+```tsx title="CheckboxGroup.stories.ts"
+// Replace the @storybook/web-components-vite package with @storybook/web-components if you're not using Storybook 9.0
+import { Meta, StoryObj } from "@storybook/web-components-vite";
+
+import { html } from 'lit';
+
+/*
+ * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+ * Refer to the Storybook documentation for the correct package and imports for earlier versions.
+ */
+import { expect } from "storybook/test";
+
 import { Checkbox } from "../src/checkbox";
 import { CheckboxGroup } from "../src/checkbox-group";
 
@@ -94,7 +105,7 @@ export const Required: Story = {
       >
     </checkbox-group>
   `,
-  async play({ canvas }) {
+  play: async ({ canvas, userEvent }) => {
     const checkboxes = await canvas.findAllByShadowRole("checkbox");
     const firstCheckbox = checkboxes[0];
     await userEvent.click(firstCheckbox); // select

--- a/src/content/playwright/configure.mdx
+++ b/src/content/playwright/configure.mdx
@@ -50,7 +50,7 @@ The Chromatic [Playwright Fixture](https://playwright.dev/docs-fixtures) can be 
 
 You can also override them for specific tests by adding the [`test.use()`](https://playwright.dev/docs/api/class-test#test-use) method in your test file and provide the required options:
 
-```ts title="HomePage.spec.js|ts"
+```ts title="tests/HomePage.spec.js|ts"
 test.describe("HomePage", () => {
   // 👇 Overrides the option in the test.
   test.use({ disableAutoSnapshot: true });

--- a/src/content/playwright/targeted-snapshots.md
+++ b/src/content/playwright/targeted-snapshots.md
@@ -12,7 +12,7 @@ By default, Chromatic takes a snapshot at the end of every Playwright test, whet
 
 `takeSnapshot` is especially useful for capturing a snapshot of your UI’s appearance when your UI reaches a specific state mid-test:
 
-```js
+```js title="tests/Example.spec.js|ts"
 import { test, expect, takeSnapshot } from "@chromatic-com/playwright";
 
 // 👇 Add testInfo parameter

--- a/src/content/snapshot/animations.mdx
+++ b/src/content/snapshot/animations.mdx
@@ -34,17 +34,17 @@ By default, CSS animations are paused at the end of their animation cycle (i.e.,
 
     import { Product } from "./Product";
 
-    const meta: Meta<typeof Product> = {
+    const meta = {
       component: Product,
       title: "Product",
       parameters: {
         // Overrides the default behavior and pauses the animation at the first frame at the component level for all stories.
         chromatic: { pauseAnimationAtEnd: false },
       },
-    };
+    } satisfies Meta<typeof Product>;
 
     export default meta;
-    type Story = StoryObj<typeof Product>;
+    type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
       play: async ({ canvasElement }) => {
@@ -228,13 +228,13 @@ import { expect, within, waitFor } from "@storybook/test";
 
 import { Button } from "./Button";
 
-const meta: Meta<typeof Button> = {
+const meta = {
   component: Button,
   title: "Button",
-};
+} satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof Button>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvasElement }) => {

--- a/src/content/snapshot/animations.mdx
+++ b/src/content/snapshot/animations.mdx
@@ -26,11 +26,10 @@ By default, CSS animations are paused at the end of their animation cycle (i.e.,
     import type { Meta, StoryObj } from "@storybook/your-framework";
 
     /*
-     * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-     * import { within } from "@storybook/testing-library";
-     * import { expect } from "@storybook/jest";
+     * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+     * Refer to the Storybook documentation for the correct package and imports for earlier versions.
     */
-    import { expect, within } from "@storybook/test";
+    import { expect } from "storybook/test";
 
     import { Product } from "./Product";
 
@@ -47,8 +46,7 @@ By default, CSS animations are paused at the end of their animation cycle (i.e.,
     type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
-      play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
+      play: async ({ canvas }) => {
         await expect(canvas.getByText("Product details")).toBeInTheDocument();
       },
     };
@@ -220,11 +218,10 @@ Lastly, add a `play()` function to the story file that asserts that the animatio
 import type { Meta, StoryObj } from "@storybook/your-framework";
 
 /*
- * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
- * import { within } from "@storybook/testing-library";
- * import { expect } from "@storybook/jest";
+ * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+ * Refer to the Storybook documentation for the correct package and imports for earlier versions.
  */
-import { expect, within, waitFor } from "@storybook/test";
+import { expect, waitFor } from "storybook/test";
 
 import { Button } from "./Button";
 
@@ -237,8 +234,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+  play: async ({ canvas }) => {
     await waitFor(
       async () => {
         await expect(canvas.getByTestId("animated-element")).toHaveAttribute(
@@ -263,7 +259,11 @@ export const Default: Story = {
 Additionally, you can turn this into a utility in order to reuse in other stories. If you happen to have multiple animated elements, there's some adjustments you can do to make this work. Here's an example below that both incorporates multiple animated elements and creates a utility for reuse in other stories.
 
 ```tsx title="MyComponent.stories.tsx"
-import { screen } from "@storybook/test";
+/* 
+* Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+* Refer to the Storybook documentation for the correct package and imports for earlier versions.
+*/
+import { screen, waitFor } from "storybook/test";
 
 const waitForAllAnimationsToComplete = async () => {
   return waitFor(

--- a/src/content/snapshot/delay.mdx
+++ b/src/content/snapshot/delay.mdx
@@ -34,17 +34,17 @@ Chromatic has a multistage timeout for capturing a snapshot: 15 seconds to rende
 
   import { Categories } from "./Categories";
 
-  const meta: Meta<typeof Categories> = {
+  const meta = {
     component: Categories,
     title: "Categories",
     parameters: {
       // Sets the delay (in milliseconds) at the component level for all stories.
       chromatic: { delay: 300 },
     },
-  };
+  } satisfies Meta<typeof Categories>;
 
   export default meta;
-  type Story = StoryObj<typeof Categories>;
+  type Story = StoryObj<typeof meta>;
 
   export const Default: Story = {
     play: async ({ canvasElement }) => {
@@ -110,13 +110,13 @@ If you need additional control when Chromatic captures a snapshot, you can adjus
 
   import { Categories } from "./Categories";
 
-  const meta: Meta<typeof Categories> = {
+  const meta = {
     component: Categories,
     title: "Categories",
-  };
+  } satisfies Meta<typeof Categories>;
 
   export default meta;
-  type Story = StoryObj<typeof Categories>;
+  type Story = StoryObj<typeof meta>;
 
   export const Default: Story = {
     play: async ({ canvasElement }) => {

--- a/src/content/snapshot/delay.mdx
+++ b/src/content/snapshot/delay.mdx
@@ -26,11 +26,10 @@ Chromatic has a multistage timeout for capturing a snapshot: 15 seconds to rende
   import type { Meta, StoryObj } from "@storybook/your-framework";
 
   /*
-   * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-   * import { within } from "@storybook/testing-library";
-   * import { expect } from "@storybook/jest";
+   * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+   * Refer to the Storybook documentation for the correct package and imports for earlier versions.
    */
-  import { expect, within } from "@storybook/test";
+  import { expect } from "storybook/test";
 
   import { Categories } from "./Categories";
 
@@ -47,8 +46,7 @@ Chromatic has a multistage timeout for capturing a snapshot: 15 seconds to rende
   type Story = StoryObj<typeof meta>;
 
   export const Default: Story = {
-    play: async ({ canvasElement }) => {
-      const canvas = within(canvasElement);
+    play: async ({ canvas }) => {
       await expect(canvas.getByText("Available Categories")).toBeInTheDocument();
     },
   };
@@ -102,11 +100,10 @@ If you need additional control when Chromatic captures a snapshot, you can adjus
   import type { Meta, StoryObj } from "@storybook/your-framework";
 
   /*
-  * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-  * import { userEvent, waitFor, within } from "@storybook/testing-library";
-  * import { expect } from "@storybook/jest";
+  * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+  * Refer to the Storybook documentation for the correct package and imports for earlier versions.
   */
-  import { expect, userEvent, waitFor, within } from "@storybook/test";
+  import { expect, waitFor, within } from "storybook/test";
 
   import { Categories } from "./Categories";
 
@@ -119,21 +116,15 @@ If you need additional control when Chromatic captures a snapshot, you can adjus
   type Story = StoryObj<typeof meta>;
 
   export const Default: Story = {
-    play: async ({ canvasElement }) => {
-      // Assigns canvas to the component root element
-      const canvas = within(canvasElement);
-
+    play: async ({ canvas, userEvent }) => {
       const LoadMoreButton = await canvas.getByRole("button", { name: "Load more" });
-
       await userEvent.click(LoadMoreButton);
 
       // Wait for the below assertion not throwing an error (default timeout is 1000ms)
       // This is especially useful when you have an asynchronous action or component that you want to wait for before taking a snapshot
       await waitFor(async () => {
         const ItemList = await canvas.getByLabelText("listitems");
-
-        const numberOfItems = await within(categories).findAllByRole("link");
-
+        const numberOfItems = await within(ItemList).findAllByRole("link");
         expect(numberOfItems).toHaveLength(0);
       });
     },
@@ -141,19 +132,15 @@ If you need additional control when Chromatic captures a snapshot, you can adjus
 
   // Emulates a delayed story by setting a timeout of 10 seconds to allow the component to load the items and ensure that the list has 20 items rendered in the DOM
   export const WithManualTimeout: Story = {
-    play: async ({ canvasElement }) => {
-      // Assigns canvas to the component root element
-      const canvas = within(canvasElement);
+    play: async ({ canvas, userEvent }) => {
       const LoadMoreButton = await canvas.getByTestId("button");
-
       await userEvent.click(LoadMoreButton);
+
       // This sets a timeout of 10 seconds and verifies that there are 20 items in the list
       await new Promise((resolve) => setTimeout(resolve, 10000));
 
       const ItemList = await canvas.getByLabelText("listitems");
-
-      const numberOfItems = await within(categories).findAllByRole("link");
-
+      const numberOfItems = await within(ItemList).findAllByRole("link");
       expect(numberOfItems).toHaveLength(20);
     },
   };

--- a/src/content/snapshot/disable-snapshots.mdx
+++ b/src/content/snapshot/disable-snapshots.mdx
@@ -20,19 +20,20 @@ If you're running tests with Storybook, you can enable the `disableSnapshot` opt
 ```ts title="src/components/NotFound.stories.ts|tsx"
 // Adjust this import to match your framework (e.g., nextjs, vue3-vite)
 import type { Meta, StoryObj } from "@storybook/your-framework";
+
 import { NotFound } from "./NotFound";
 
-const meta: Meta<typeof NotFound> = {
+const meta = {
   component: NotFound,
   title: "NotFound",
   parameters: {
     // Disables Chromatic's snapshotting on a component level
     chromatic: { disableSnapshot: true },
   },
-};
+} satisfies Meta<typeof NotFound>;
 
 export default meta;
-type Story = StoryObj<typeof NotFound>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 ```

--- a/src/content/snapshot/hoverfocus.mdx
+++ b/src/content/snapshot/hoverfocus.mdx
@@ -32,13 +32,13 @@ If you're working with a component that relies on JavaScript to trigger hover st
 
     import { LoginForm } from "./LoginForm";
 
-    const meta: Meta<typeof LoginForm> = {
+    const meta = {
       component: LoginForm,
       title: "LoginForm",
-    };
+    } satisfies Meta<typeof LoginForm>;
 
     export default meta;
-    type Story = StoryObj<typeof LoginForm>;
+    type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
       play: async ({ canvasElement }) => {
@@ -105,13 +105,13 @@ import type { Meta, StoryObj } from "@storybook/your-framework";
 
 import { LoginForm } from "./LoginForm";
 
-const meta: Meta<typeof LoginForm> = {
+const meta = {
   component: LoginForm,
   title: "LoginForm",
-};
+} satisfies Meta<typeof LoginForm>;
 
 export default meta;
-type Story = StoryObj<typeof LoginForm>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   parameters: {
@@ -147,13 +147,13 @@ import type { Meta, StoryObj } from "@storybook/your-framework";
 
 import { MyComponent } from "./MyComponent";
 
-const meta: Meta<typeof MyComponent> = {
+const meta = {
   component: MyComponent,
   title: "MyComponent",
-};
+} satisfies Meta<typeof MyComponent>;
 
 export default meta;
-type Story = StoryObj<typeof MyComponent>;
+type Story = StoryObj<typeof meta>;
 
 export const HoverStatewithClass: Story = {
   args: {
@@ -169,11 +169,7 @@ export const ActiveStatewithClass: Story = {
 ```
 
 <div class="aside">
-  ℹ️ This approach requires manually toggling the class names in your
-  component's test to simulate the necessary states. If you're using a CSS-in-JS
-  framework, you can
-  [automate](https://github.com/Workday/canvas-kit/pull/377/files) this process
-  by creating a JavaScript wrapper that adds the class names programmatically.
+  ℹ️ This approach requires manually toggling the class names in your component's test to simulate the necessary states. If you're using a CSS-in-JS framework, you can [automate](https://github.com/Workday/canvas-kit/pull/377/files) this process by creating a JavaScript wrapper that adds the class names programmatically.
 </div>
 
 ## Focusing DOM elements
@@ -197,13 +193,13 @@ import { expect, userEvent, within } from "@storybook/test";
 
 import { LoginForm } from "./LoginForm";
 
-const meta: Meta<typeof LoginForm> = {
+const meta = {
   component: LoginForm,
   title: "LoginForm",
-};
+} satisfies Meta<typeof LoginForm>;
 
 export default meta;
-type Story = StoryObj<typeof LoginForm>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvasElement }) => {
@@ -278,7 +274,7 @@ import type { Meta, StoryObj } from "@storybook/your-framework";
 
 import { LoginForm } from "./LoginForm";
 
-const meta: Meta<typeof LoginForm> = {
+const meta = {
  component: LoginForm,
  title: "LoginForm",
  decorators: [
@@ -288,7 +284,7 @@ const meta: Meta<typeof LoginForm> = {
       </div>
     ),
   ],
-};
+} satisfies Meta<typeof LoginForm>;
 
 export default meta;
 ```

--- a/src/content/snapshot/hoverfocus.mdx
+++ b/src/content/snapshot/hoverfocus.mdx
@@ -24,11 +24,10 @@ If you're working with a component that relies on JavaScript to trigger hover st
     import type { Meta, StoryObj } from "@storybook/your-framework";
 
     /*
-    * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-    * import { userEvent, waitFor, within } from "@storybook/testing-library";
-    * import { expect } from "@storybook/jest";
+    * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+    * Refer to the Storybook documentation for the correct package and imports for earlier versions.
     */
-    import { expect, userEvent, waitFor, within } from "@storybook/test";
+    import { expect, waitFor } from "storybook/test";
 
     import { LoginForm } from "./LoginForm";
 
@@ -41,8 +40,7 @@ If you're working with a component that relies on JavaScript to trigger hover st
     type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
-      play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
+      play: async ({ canvas, userEvent }) => {
         await userEvent.type(canvas.getByLabelText("email"), "test@email.com");
 
         await userEvent.type(canvas.getByLabelText('password'), "password");
@@ -185,11 +183,10 @@ If you're working with a component that provides a visual response to the user f
 import type { Meta, StoryObj } from "@storybook/your-framework";
 
 /*
- * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
- * import { userEvent, within } from "@storybook/testing-library";
- * import { expect } from "@storybook/jest";
+ * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+ * Refer to the Storybook documentation for the correct package and imports for earlier versions.
  */
-import { expect, userEvent, within } from "@storybook/test";
+import { expect } from "storybook/test";
 
 import { LoginForm } from "./LoginForm";
 
@@ -202,8 +199,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+  play: async ({ canvas, userEvent }) => {
     await userEvent.type(canvas.getByLabelText("email"), "test@email.com");
     await userEvent.type(canvas.getByLabelText("password"), "KC@2N6^?vsV+)w1t");
 

--- a/src/content/snapshot/ignoring-elements.mdx
+++ b/src/content/snapshot/ignoring-elements.mdx
@@ -53,11 +53,10 @@ You can specify a list of CSS selectors with the `ignoreSelectors` option to ign
     import type { Meta, StoryObj } from "@storybook/your-framework";
 
     /*
-    * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-    * import { within } from "@storybook/testing-library";
-    * import { expect } from "@storybook/jest";
+    * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+    * Refer to the Storybook documentation for the correct package and imports for earlier versions.
     */
-    import { expect, within } from "@storybook/test";
+    import { expect } from "storybook/test";
 
     import { Product } from "./Product";
 
@@ -74,8 +73,7 @@ You can specify a list of CSS selectors with the `ignoreSelectors` option to ign
     type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
-      play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
+      play: async ({ canvas }) => {
         await expect(canvas.getByText("Product details")).toBeInTheDocument();
       },
     };

--- a/src/content/snapshot/ignoring-elements.mdx
+++ b/src/content/snapshot/ignoring-elements.mdx
@@ -61,17 +61,17 @@ You can specify a list of CSS selectors with the `ignoreSelectors` option to ign
 
     import { Product } from "./Product";
 
-    const meta: Meta<typeof Product> = {
+    const meta = {
       component: Product,
       title: "Product",
       parameters: {
         // Ignores the diff for elements targeted by the specified list of selectors
         chromatic: { ignoreSelectors: ['.product-price'] },
       },
-    };
+    } satisfies Meta<typeof Product>;
 
     export default meta;
-    type Story = StoryObj<typeof Product>;
+    type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
       play: async ({ canvasElement }) => {

--- a/src/content/snapshot/media-features.mdx
+++ b/src/content/snapshot/media-features.mdx
@@ -33,17 +33,17 @@ The [`forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/fo
 
     import { LoginForm } from "./LoginForm";
 
-    const meta: Meta<typeof LoginForm> = {
+    const meta = {
       component: LoginForm,
       title: "LoginForm",
       parameters: {
         // Enables the forcedColors option at the component level for all stories.
         chromatic: { forcedColors: "active" },
       },
-    };
+    } satisfies Meta<typeof LoginForm>;
 
     export default meta;
-    type Story = StoryObj<typeof LoginForm>;
+    type Story = StoryObj<typeof meta>;
 
     export const WithForcedColors: Story = {
       play: async ({ canvasElement }) => {
@@ -120,17 +120,17 @@ The [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/
 
     import { LoginForm } from "./LoginForm";
 
-    const meta: Meta<typeof LoginForm> = {
+    const meta = {
       component: LoginForm,
       title: "LoginForm",
       parameters: {
         // Enables the prefersReducedMotion option at the component level for all stories.
         chromatic: { prefersReducedMotion: "reduce" },
       },
-    };
+    } satisfies Meta<typeof LoginForm>;
 
     export default meta;
-    type Story = StoryObj<typeof LoginForm>;
+    type Story = StoryObj<typeof meta>;
 
     export const WithReducedMotion: Story = {
       play: async ({ canvasElement }) => {
@@ -197,7 +197,7 @@ import type { Meta, StoryObj } from "@storybook/your-framework";
 
 import { UserAccount } from "./UserAccount";
 
-const meta: Meta<typeof UserAccount> = {
+const meta = {
   component: UserAccount,
   title: "UserAccount",
   parameters: {
@@ -206,10 +206,10 @@ const meta: Meta<typeof UserAccount> = {
       media: "print",
     },
   },
-};
+} satisfies Meta<typeof UserAccount>;
 
 export default meta;
-type Story = StoryObj<typeof UserAccount>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 ```
@@ -245,13 +245,13 @@ import { allModes } from "../../.storybook/modes";
 
 import { UserAccount } from "./UserAccount";
 
-const meta: Meta<typeof UserAccount> = {
+const meta = {
   component: UserAccount,
   title: "UserAccount",
-};
+} satisfies Meta<typeof UserAccount>;
 
 export default meta;
-type Story = StoryObj<typeof UserAccount>;
+type Story = StoryObj<typeof meta>;
 
 /*
  * Combines modes with print media styles

--- a/src/content/snapshot/media-features.mdx
+++ b/src/content/snapshot/media-features.mdx
@@ -26,10 +26,10 @@ The [`forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/fo
     import type { Meta, StoryObj } from "@storybook/your-framework";
 
     /*
-     * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-     * import { userEvent, within } from "@storybook/testing-library";
+     * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+     * Refer to the Storybook documentation for the correct package and imports for earlier versions.
     */
-    import { userEvent, within } from "@storybook/test";
+    import { userEvent } from "storybook/test";
 
     import { LoginForm } from "./LoginForm";
 
@@ -46,9 +46,7 @@ The [`forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/fo
     type Story = StoryObj<typeof meta>;
 
     export const WithForcedColors: Story = {
-      play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-
+      play: async ({ canvas }) => {
         await userEvent.type(canvas.getByLabelText("email"), "test@email.com");
         await userEvent.type(canvas.getByLabelText("password"), "KC@2N6^?vsV+)w1t");
         await canvas.getByRole("button", { name: "Login" }).click();
@@ -113,10 +111,10 @@ The [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/
     import type { Meta, StoryObj } from "@storybook/your-framework";
 
     /*
-     * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-     * import { userEvent, within } from "@storybook/testing-library";
+     * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+     * Refer to the Storybook documentation for the correct package and imports for earlier versions.
     */
-    import { userEvent, within } from "@storybook/test";
+    import { userEvent } from "storybook/test";
 
     import { LoginForm } from "./LoginForm";
 
@@ -133,9 +131,7 @@ The [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/
     type Story = StoryObj<typeof meta>;
 
     export const WithReducedMotion: Story = {
-      play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-
+      play: async ({ canvas }) => {
         await userEvent.type(canvas.getByLabelText("email"), "test@email.com");
         await userEvent.type(canvas.getByLabelText("password"), "KC@2N6^?vsV+)w1t");
         await canvas.getByRole('button', { name: "Login" }).click();

--- a/src/content/snapshot/threshold.mdx
+++ b/src/content/snapshot/threshold.mdx
@@ -36,17 +36,17 @@ If you need to customize how Chromatic identifies visual changes in your UI, add
 
     import { UserAccount } from "./UserAccount";
 
-    const meta: Meta<typeof UserAccount> = {
+    const meta = {
       component: UserAccount,
       title: "UserAccount",
       parameters: {
         // Sets the threshold for 0.2 at the component level for all stories.
         chromatic: { diffThreshold: 0.2 },
       },
-    };
+    } satisfies Meta<typeof UserAccount>;
 
     export default meta;
-    type Story = StoryObj<typeof UserAccount>;
+    type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
       play: async ({ canvasElement }) => {
@@ -116,17 +116,17 @@ To enable this feature and allow Chromatic to automatically detect anti-aliased 
 
     import { UserAccount } from "./UserAccount";
 
-    const meta: Meta<typeof UserAccount> = {
+    const meta = {
       component: UserAccount,
       title: "UserAccount",
       parameters: {
         // Configures the component to include anti-aliasing in the diff calculation.
         chromatic: { diffIncludeAntiAliasing: true },
       },
-    };
+    } satisfies Meta<typeof UserAccount>;
 
     export default meta;
-    type Story = StoryObj<typeof UserAccount>;
+    type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
       play: async ({ canvasElement }) => {

--- a/src/content/snapshot/threshold.mdx
+++ b/src/content/snapshot/threshold.mdx
@@ -28,11 +28,10 @@ If you need to customize how Chromatic identifies visual changes in your UI, add
     import type { Meta, StoryObj } from "@storybook/your-framework";
 
     /*
-     * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-     * import { within } from "@storybook/testing-library";
-     * import { expect } from "@storybook/jest";
+     * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+     * Refer to the Storybook documentation for the correct package and imports for earlier versions.
     */
-    import { expect, within } from "@storybook/test";
+    import { expect } from "storybook/test";
 
     import { UserAccount } from "./UserAccount";
 
@@ -49,8 +48,7 @@ If you need to customize how Chromatic identifies visual changes in your UI, add
     type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
-      play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
+      play: async ({ canvas }) => {
         await expect(canvas.getByText("Welcome, username")).toBeInTheDocument();
       },
     };
@@ -108,11 +106,10 @@ To enable this feature and allow Chromatic to automatically detect anti-aliased 
     import type { Meta, StoryObj } from "@storybook/your-framework";
 
     /*
-     * Replace the @storybook/test package with the following if you are using a version of Storybook earlier than 8.0:
-     * import { within } from "@storybook/testing-library";
-     * import { expect } from "@storybook/jest";
+     * Replace the storybook/test import with `@storybook/test` and adjust the stories accordingly if you're not using Storybook 9.0.
+     * Refer to the Storybook documentation for the correct package and imports for earlier versions.
     */
-    import { expect, within } from "@storybook/test";
+    import { expect } from "storybook/test";
 
     import { UserAccount } from "./UserAccount";
 
@@ -129,8 +126,7 @@ To enable this feature and allow Chromatic to automatically detect anti-aliased 
     type Story = StoryObj<typeof meta>;
 
     export const Default: Story = {
-      play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
+      play: async ({ canvas }) => {
         await expect(canvas.getByText("Welcome, username")).toBeInTheDocument();
       },
     };

--- a/src/content/snapshot/troubleshooting-snapshots.md
+++ b/src/content/snapshot/troubleshooting-snapshots.md
@@ -191,7 +191,7 @@ To set the height, you can add a decorator for stories that wraps them in a cont
 
 ```ts title="MyComponent.stories.js|jsx"
 // Adjust this import to match your framework (e.g., nextjs, vue3-vite)
-import type { Meta, StoryObj } from "@storybook/your-framework";
+import type { Meta } from "@storybook/your-framework";
 
 import { MyComponent } from "./MyComponent";
 

--- a/src/content/snapshot/troubleshooting-snapshots.md
+++ b/src/content/snapshot/troubleshooting-snapshots.md
@@ -189,12 +189,13 @@ When Chromatic takes a screenshot for an element that has a viewport-relative he
 
 To set the height, you can add a decorator for stories that wraps them in a container with a fixed height:
 
-```js
-// MyComponent.stories.js|jsx
+```ts title="MyComponent.stories.js|jsx"
+// Adjust this import to match your framework (e.g., nextjs, vue3-vite)
+import type { Meta, StoryObj } from "@storybook/your-framework";
 
 import { MyComponent } from "./MyComponent";
 
-export default {
+const meta = {
   component: MyComponent,
   title: "Example Story",
   decorators: [
@@ -204,7 +205,7 @@ export default {
       </div>
     ),
   ],
-};
+} satisfies Meta<typeof MyComponent>;
 ```
 
 </details>

--- a/src/content/snapshot/viewports.mdx
+++ b/src/content/snapshot/viewports.mdx
@@ -13,7 +13,7 @@ UI components respond and adapt to different device widths. Chromatic streamline
 
 For Storybook, viewports are configured using the [Modes API](/docs/modes), which allows you to set global configurations that affect how a component renders (e.g., viewport size, theme & locale).
 
-Chromatic also integrates with Storybook's viewport feature. You can specify viewports by the names configured in Storybook's `.storybook/preview.js` file. And if a story has a `defaultViewport` set, Chromatic will automatically use that to capture the snapshot.
+Chromatic also integrates with Storybook's viewport feature. You can specify viewports by the names configured in Storybook's `.storybook/preview.js|ts` file. And if a story has a `defaultViewport` set, Chromatic will automatically use that to capture the snapshot.
 
 For detailed usage instructions, refer to the [**configure viewports for stories**](/docs/modes/viewports) page.
 

--- a/src/content/troubleshooting/faq/why-are-storybook-and-chromatic-story-names-different.mdx
+++ b/src/content/troubleshooting/faq/why-are-storybook-and-chromatic-story-names-different.mdx
@@ -9,22 +9,19 @@ section: "usage"
 
 Chromatic follows Storybook's [naming best practice](https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy). The last level in the hierarchy is tracked as the component name.
 
-```tsx
-// Button.stories.ts|tsx
-
+```tsx title="Button.stories.ts|tsx"
 // Replace your-framework with the framework you are using (e.g., nextjs, vue3-vite)
 import type { Meta, StoryObj } from '@storybook/your-framework';
 
 import { Button } from "./Button";
 
-const meta: Meta<typeof Button> = {
+const meta = {
   title: "App/Components/Button",
   component: Button,
-};
+} satisfies Meta<typeof Button>;
 
 export default meta;
-type Story = StoryObj<typeof Button>;
-
+type Story = StoryObj<typeof meta>;
 
 /*
  *👇 Render functions are a framework-specific feature to allow you control over how the component renders.

--- a/src/content/turbosnap/turbosnap-dependency-tracing.mdx
+++ b/src/content/turbosnap/turbosnap-dependency-tracing.mdx
@@ -108,9 +108,10 @@ The asset object for a story file usually looks a bit different:
 
 Under "reasons," you'll notice a `moduleName` resembling a path pattern. In the full, untrimmed file, the `issuerPath`'s are `"./storybook-config-entry.js"` and `"./storybook-stories.js"`. That's because the dependency is related to this project's Storybook configuration:
 
-```js title=".storybook/main.js"
-/** @type { import('@storybook/react-webpack5').StorybookConfig } */
-const config = {
+```ts title=".storybook/main.ts"
+import type { StorybookConfig } from "@storybook/react-webpack5";
+
+const config: StorybookConfig = {
   stories: [
     {
       directory: "../",

--- a/src/content/visualTests/diff-inspector.mdx
+++ b/src/content/visualTests/diff-inspector.mdx
@@ -58,57 +58,54 @@ Customize how Chromatic identifies visual changes by adjusting the `diffThreshol
 
 <IntegrationSnippets>
   <Fragment slot="storybook">
-```ts
-// MyComponent.stories.ts|tsx
+    ```ts title="MyComponent.stories.ts|tsx"
 
-// Replace your-framework with the framework you are using (e.g., nextjs, vue3-vite)
-import type { Meta, StoryObj } from "@storybook/your-framework";
+    // Replace your-framework with the framework you are using (e.g., nextjs, vue3-vite)
+    import type { Meta, StoryObj } from "@storybook/your-framework";
 
-import { MyComponent } from "./MyComponent";
+    import { MyComponent } from "./MyComponent";
 
-const meta: Meta<typeof MyComponent> = {
-  component: MyComponent,
-  title: "MyComponent",
-};
+    const meta = {
+      component: MyComponent,
+      title: "MyComponent",
+    } satisfies Meta<typeof MyComponent>;
 
-export default meta;
-type Story = StoryObj<typeof MyComponent>;
+    export default meta;
+    type Story = StoryObj<typeof meta>;
 
-export const StoryName: Story = {
-  args: {
-    with: "props",
-  },
-  parameters: {
-    // Sets the diffThreshold for 0.2 for a specific story.
-    chromatic: { diffThreshold: 0.2 },
-  },
-};
-```
+    export const StoryName: Story = {
+      args: {
+        with: "props",
+      },
+      parameters: {
+        // Sets the diffThreshold for 0.2 for a specific story.
+        chromatic: { diffThreshold: 0.2 },
+      },
+    };
+    ```
   </Fragment>
   <Fragment slot="playwright">
-```js
-// mytest.spec.js
+    ```js title="tests/mytest.spec.js"
+    test.describe("some block", () => {
+      // 👇 your option overrides
+      test.use({ diffThreshold: 0.2 });
 
-test.describe("some block", () => {
-  // 👇 your option overrides
-  test.use({ diffThreshold: 0.2 });
-
-  test("some test", async ({ page }) => {
-    // ...
-  });
-});
-```
+      test("some test", async ({ page }) => {
+        await page.goto("https://some-url.com");
+        // ... your test code
+      });
+    });
+    ```
   </Fragment>
   <Fragment slot="cypress">
-```js
-// some-test.cy.ts
-
-it("A test that does something", {
-  env: { diffThreshold: 0.2 }
-}, () => {
-  cy.visit("https://some-url.com");
-});
-```
+    ```js title="cypress/e2e/some-test.cy.js|ts"
+    it("A test that does something", {
+      env: { diffThreshold: 0.2 }
+    }, () => {
+      cy.visit("https://some-url.com");
+      // ... your test code
+    });
+    ```
   </Fragment>
 </IntegrationSnippets>
 


### PR DESCRIPTION
Addresses [CHDX-1077](https://linear.app/chromaui/issue/CHDX-1077/fact-check-framework-references)

With this pull request, the examples, including the interaction test examples, were updated to Storybook's current stable release.

What was done:
- Adjusted the examples in the documentation (minus the Modes documentation) to be TypeScript-based and use type safety constructs
- Fixed examples for inconsistencies, typos, and other issues
- Fixed some invalid links in the docs