### PR TITLE
Docs: Minor A11y fixes

### DIFF
--- a/src/content/accessibilityTests/accessibility-configure.mdx
+++ b/src/content/accessibilityTests/accessibility-configure.mdx
@@ -116,64 +116,6 @@ const preview: Preview = {
 export default preview;
 ```
 
-## Custom rules
-
-Axe allows you to add custom [rules and checks](https://github.com/dequelabs/axe-core/blob/64d409dc5862e9fdebcec87a0a269ab3f3e71ad2/doc/rule-development.md). You can configure these rules via the `a11y.config.rules` property. Chromatic will also run these custom rules and report any violations within the web app.
-
-```tsx title="RestaurantCard.stories.ts|js"
-// Replace your-framework with the framework you are using (e.g., nextjs, vue3-vite)
-import type { Meta, StoryObj } from "@storybook/your-framework";
-import { restaurants } from "../../stub/restaurants";
-import { RestaurantCard } from "./RestaurantCard";
-
-const meta = {
-  title: "Components/RestaurantCard",
-  component: RestaurantCard,
-  parameters: {
-    a11y: {
-      config: {
-        rules: [
-          {
-            id: "minimum-paragraph-length",
-            selector: "p",
-            impact: "critical",
-            all: ["paragraph-minimum-text"],
-            any: [],
-            none: [],
-            metadata: {
-              description: "Ensures paragraphs have meaningful content",
-              help: "Paragraphs should contain at least 5 characters",
-            },
-          },
-        ],
-        checks: [
-          {
-            id: "paragraph-minimum-text",
-            evaluate: function evaluate(node: HTMLParagraphElement) {
-              const textContent = node.textContent?.trim();
-              return textContent && textContent.length > 0
-                ? textContent.length > 50
-                : false;
-            },
-          },
-        ],
-      },
-    },
-  },
-} satisfies Meta<typeof RestaurantCard>;
-
-export default meta;
-
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
-  args: {
-    ...restaurants[0],
-    name: "Burger Kingdom",
-  },
-} satisfies Story;
-```
-
 ## Disable accessibility tests
 
 ### Both in Storybook and Chromatic

--- a/src/content/accessibilityTests/accessibility.mdx
+++ b/src/content/accessibilityTests/accessibility.mdx
@@ -190,7 +190,7 @@ Yes. TurboSnap analyzes your project’s Git history and [dependency graph](htt
 <details>
 <summary>Do accessibility tests support modes?</summary>
 
-Yes, if you've configured modes for a story, Chromatic will run accessibility tests on each mode too."
+Yes, if you've configured modes for a story, Chromatic will run accessibility tests on each mode too.
 
 </details>
 
@@ -209,13 +209,18 @@ Yes. Similar to how it works for visual tests, if you've set up viewports for a 
 </details>
 
 <details>
+<summary>Do accessibility tests support custom rules?</summary>
+
+Not yet. This means that if you have custom [rules and checks](https://github.com/dequelabs/axe-core/blob/64d409dc5862e9fdebcec87a0a269ab3f3e71ad2/doc/rule-development.md) defined in your Storybook configuration, they will not run with accessibility tests.
+
+</details>
+
+<details>
 <summary>Does Chromatic check for prefers-reduced-motion violations?</summary>
 
 Not yet
 
 </details>
-
----
 
 ## Troubleshooting
 


### PR DESCRIPTION
With this pull request the A11y documentation was updated to fix some typos and remove an unsupported option.

What was done:
- Fixed a minor typo
- Removed the custom rules section from the configuration section to avoid confusion

@winkerVSbecks,  when you have a moment, can you check this and follow up with any feedback you may have? Thanks in advance