### PR TITLE
Docs: CI - Updates images to latest

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -71,7 +71,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.53.1-noble
+            container: mcr.microsoft.com/playwright:v1.54.1-noble
             steps:
               - checkout: self
                 displayName: "Get Full Git History"
@@ -153,7 +153,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Cypress
             displayName: "Run Cypress"
-            container: cypress/browsers:node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1
+            container: cypress/browsers:node-22.17.0-chrome-138.0.7204.92-1-ff-140.0.2-edge-138.0.3351.65-1
             variables:
               npm_config_cache: $(Pipeline.Workspace)/.npm
             steps:

--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -39,7 +39,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.12.0"
+                  version: "22.17.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -79,7 +79,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.12.0"
+                  version: "22.17.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -115,7 +115,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.12.0"
+                  version: "22.17.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -163,7 +163,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.12.0"
+                  version: "22.17.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -201,7 +201,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.12.0"
+                  version: "22.17.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -57,7 +57,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.53.1-noble
+                  image: mcr.microsoft.com/playwright:v1.54.1-noble
                   caches:
                     - npm
                     - node
@@ -96,7 +96,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - step:
                 name: "Cypress"
                 # Configure the ELECTRON_EXTRA_LAUNCH_ARGS environment variable in your project settings to run Cypress tests with Chromatic.
-                image: cypress/browsers:node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1
+                image: cypress/browsers:node-22.17.0-chrome-138.0.7204.92-1-ff-140.0.2-edge-138.0.3351.65-1
                 caches:
                   - npm
                   - node

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -25,7 +25,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:22.12.0
+          - image: cimg/node:22.17.0
         working_directory: ~/repo
 
     jobs:
@@ -63,7 +63,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:22.12.0
+          - image: cimg/node:22.17.0
         working_directory: ~/repo
 
     jobs:
@@ -135,7 +135,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:22.12.0
+          - image: cimg/node:22.17.0
         working_directory: ~/repo
 
     jobs:

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-noble-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.53.1-noble
+          - image: mcr.microsoft.com/playwright:v1.54.1-noble
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
@@ -131,7 +131,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       cypress:
         docker:
-          - image: cypress/browsers:node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1
+          - image: cypress/browsers:node-22.17.0-chrome-138.0.7204.92-1-ff-140.0.2-edge-138.0.3351.65-1
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -42,7 +42,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.53.1-noble
+        container: mcr.microsoft.com/playwright:v1.54.1-noble
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.
@@ -68,7 +68,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Cypress"
         displayName: "Run Cypress tests"
-        container: cypress/browsers:node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1
+        container: cypress/browsers:node-22.17.0-chrome-138.0.7204.92-1-ff-140.0.2-edge-138.0.3351.65-1
         environment:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         options:

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -35,7 +35,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.12.0
+              node-version: 22.17.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -63,7 +63,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.12.0
+              node-version: 22.17.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -89,7 +89,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.12.0
+              node-version: 22.17.0
           - name: Install dependencies
              # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -128,7 +128,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.12.0
+              node-version: 22.17.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -156,7 +156,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.12.0
+              node-version: 22.17.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -56,7 +56,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.53.1-noble
+          image: mcr.microsoft.com/playwright:v1.54.1-noble
         steps:
           - uses: actions/checkout@v4
             with:
@@ -120,7 +120,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         name: Run Cypress
         runs-on: ubuntu-latest
         container:
-          image: cypress/browsers:node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1
+          image: cypress/browsers:node-22.17.0-chrome-138.0.7204.92-1-ff-140.0.2-edge-138.0.3351.65-1
           options: --user 1001
         steps:
           - uses: actions/checkout@v4

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -59,7 +59,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.53.1-noble
+      image: mcr.microsoft.com/playwright:v1.54.1-noble
       script:
         - npx playwright test
       allow_failure: true
@@ -99,7 +99,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Cypress:
       stage: UI_Tests
       needs: []
-      image: cypress/browsers:node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1
+      image: cypress/browsers:node-22.17.0-chrome-138.0.7204.92-1-ff-140.0.2-edge-138.0.3351.65-1
       variables:
         ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
       script:

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -51,7 +51,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.53.1-noble'
+               image 'mcr.microsoft.com/playwright:v1.54.1-noble'
                reuseNode true
              }
            }
@@ -94,7 +94,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Cypress') {
            agent {
              docker {
-               image 'cypress/browsers:node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1'
+               image 'cypress/browsers:node-22.17.0-chrome-138.0.7204.92-1-ff-140.0.2-edge-138.0.3351.65-1'
                reuseNode true
              }
            }

--- a/src/content/ci/semaphore.mdx
+++ b/src/content/ci/semaphore.mdx
@@ -74,7 +74,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               os_image: ubuntu2204
             containers:
               - name: Plawyright
-                image: mcr.microsoft.com/playwright:v1.53.1-noble
+                image: mcr.microsoft.com/playwright:v1.54.1-noble
           jobs:
             - name: Run Playwright
               commands:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -27,7 +27,7 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.53.1-noble
+      image: mcr.microsoft.com/playwright:v1.54.1-noble
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,7 +97,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.53.1-noble
+  image: mcr.microsoft.com/playwright:v1.54.1-noble
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -123,7 +123,7 @@ version: 2.1
 executors:
   pw-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.53.1-noble
+      - image: mcr.microsoft.com/playwright:v1.54.1-noble
   chromatic-ui-testing:
     docker:
       - image: cimg/node:22.12.0
@@ -201,7 +201,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.53.1-noble'
+              image 'mcr.microsoft.com/playwright:v1.54.1-noble'
               reuseNode true
             }
           }
@@ -221,7 +221,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.53.1-noble'
+              image 'mcr.microsoft.com/playwright:v1.54.1-noble'
               reuseNode true
             }
           }
@@ -279,7 +279,7 @@ blocks:
           os_image: ubuntu2204
         containers:
           - name: Plawyright
-            image: mcr.microsoft.com/playwright:v1.53.1-noble
+            image: mcr.microsoft.com/playwright:v1.54.1-noble
       jobs:
         - name: Run Playwright
           commands:
@@ -318,7 +318,7 @@ image: node:jod
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.53.1-noble
+    container: mcr.microsoft.com/playwright:v1.54.1-noble
     options:
       parallel: 2
       artifacts:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.17.0
       - name: Install dependencies
         run: npm ci
       - name: Run Playwright tests
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.17.0
       - name: Install dependencies
         run: npm ci
 
@@ -126,7 +126,7 @@ executors:
       - image: mcr.microsoft.com/playwright:v1.54.1-noble
   chromatic-ui-testing:
     docker:
-      - image: cimg/node:22.12.0
+      - image: cimg/node:22.17.0
 
 jobs:
   Playwright:


### PR DESCRIPTION
With this pull request, the CI documentation was updated to include the latest releases for Playwright and Cypress to prevent known security issues in the browsers' versions.

What was done:
- Updated Playwright and Cypress CI images to latest stable versions
- Updated the Node versions referenced in the documentation to the latest stable releases

@winkerVSbecks I'm going to self merge this once the checklist clears. 
