### PR TITLE
Docs: Fix incorrect link in shared snippets

### DIFF
--- a/src/shared-snippets/setup-unlinked-project.md
+++ b/src/shared-snippets/setup-unlinked-project.md
@@ -10,7 +10,7 @@ To setup Chromatic with an "unlinked" project:
 
 Nice! You created an unlinked project. This will allow you to get started with [UI Testing](/docs) workflow regardless of the underlying git provider. You can then configure your CI system to automatically run a Chromatic build on push.
 
-The Chromatic CLI provides the option to generate a JUnit XML report of your build, which you can use to handle commit / pull request statuses yourself. See [debug options](/docs/cli#debug-options) for details.
+The Chromatic CLI provides the option to generate a JUnit XML report of your build, which you can use to handle commit / pull request statuses yourself. For details, see the configuration reference [options](/docs/configure#options).
 
 Unlinked projects have certain drawbacks:
 


### PR DESCRIPTION
With this pull request, the documentation, specifically the shared snippets component links, were updated to point at the correct location instead of the non-existent section in the documentation.

What was done:
- Fixed the link in the shared snippets component to prevent it from pointing at an incorrect location in the documentation.

@winkerVSbecks when you're able, can you take a look and provide any feedback you may have. Thanks in advance