### PR TITLE
Docs: A11y -  Fix links to non-existent sections

### DIFF
--- a/src/content/accessibilityTests/accessibility-usage.mdx
+++ b/src/content/accessibilityTests/accessibility-usage.mdx
@@ -12,7 +12,7 @@ import A11yBeta from "../../components/A11yBeta.astro";
 
 <A11yBeta />
 
-This guide will walk you through setting up and using Chromatic's accessibility testing in your workflow. To get started, you need to have Chromatic set up for your Storybook project. If you haven't done this yet, follow the [quickstart guide](https://www.chromatic.com/docs/quickstart) to get started. And ensure that you are using Storybook version 6.5+ and have [Accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing#accessibility-checks-with-a11y-addon) installed and enabled.
+This guide will walk you through setting up and using Chromatic's accessibility testing in your workflow. To get started, you need to have Chromatic set up for your Storybook project. If you haven't done this yet, follow the [quickstart guide](/docs/quickstart) to get started. And ensure that you are using Storybook version 6.5+ and have [Accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing) installed and enabled.
 
 ## 1. Enable Accessibility Tests
 

--- a/src/content/accessibilityTests/accessibility.mdx
+++ b/src/content/accessibilityTests/accessibility.mdx
@@ -41,7 +41,7 @@ By combining Chromatic and Storybook, you get instant accessibility feedback at 
 
 ### During development: Fast feedback in Storybook
 
-Storybook’s [Accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing#accessibility-checks-with-a11y-addon) simplifies running axe on individual components. You can run accessibility tests for all your stories in the background. If there are any violations, the test will fail, and you will see a summary in the sidebar. Violating elements are highlighted in Storybook’s canvas, allowing you to pinpoint the exact problem areas. You also get detailed error descriptions and guidance to help resolve issues quickly.
+Storybook’s [Accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing) simplifies running axe on individual components. You can run accessibility tests for all your stories in the background. If there are any violations, the test will fail, and you will see a summary in the sidebar. Violating elements are highlighted in Storybook’s canvas, allowing you to pinpoint the exact problem areas. You also get detailed error descriptions and guidance to help resolve issues quickly.
 
 ![Storybook UI with accessibility features annotated](../../images/a11y/addon-a11y-annotated.png)
 


### PR DESCRIPTION
With this small pull request, some of the A11y links in the documentation were fixed, as the sections no longer exist in the Storybook documentation.

What was done:
- Adjusted the links by removing the non-existent sections
- Minor fix to the link in the Accessibility usage

@winkerVSbecks if you have no objections, I'll gladly merge this once the checklist clears and get the documentation available. 