### PR TITLE
Docs: A11y report updates

### DIFF
--- a/src/content/accessibilityTests/accessibility-dashboard.mdx
+++ b/src/content/accessibilityTests/accessibility-dashboard.mdx
@@ -34,3 +34,12 @@ Chromatic provides seven days of data history with access limited to the default
 Default branch is set as the `main` branch of your project. If there is no `main` branch, Chromatic will fall back to one of `master`, `develop`, `dev` or `rc`.
 
 Enterprise plans can upgrade to the _accessibility package_ for volume pricing, and full historical data, and multi-branch tracking in the dashboard. Contact our [sales team](https://www.chromatic.com/sales) to learn more.
+
+### Frequently asked questions
+
+<details>
+<summary>Why do the impact values in the report look different from what I see in the dashboard?</summary>
+
+The CSV report uses a structured format for impact values (e.g., `3-critical`) based on axe's [accessibility guidelines](https://docs.deque.com/devtools-mobile/2023.4.19/en/impact) to facilitate data processing, sorting, and prioritization of violations. This format ensures compatibility with accessibility compliance tools and enables automated processing for regulatory submissions.
+
+</details>


### PR DESCRIPTION
Closes [CHDX-108](https://linear.app/chromaui/issue/CHDX-1087/dashboard-qa-csv-data-impact-values-confusion)

With this pull request the A11y report documentation was updated to include a small entry in the form of a frequently asked question to help users discern how the A11y violations are categorized.

What was done:
- Adjusted the A11y dashboard to include a small entry to help users get more information on how the violations are categorized in the report.