### PR TITLE
Docs: Remove A11y trial callout

### DIFF
--- a/src/content/accessibilityTests/accessibility-configure.mdx
+++ b/src/content/accessibilityTests/accessibility-configure.mdx
@@ -5,11 +5,7 @@ slug: accessibility/configure
 sidebar: { order: 3 }
 ---
 
-import A11yBeta from "../../components/A11yBeta.astro";
-
 # Configure Accessibility tests
-
-<A11yBeta />
 
 You can configure Chromatic's accessibility tests to match your project's specific requirements. By default, Chromatic runs accessibility tests with the following rules:
 

--- a/src/content/accessibilityTests/accessibility-dashboard.mdx
+++ b/src/content/accessibilityTests/accessibility-dashboard.mdx
@@ -5,11 +5,7 @@ slug: accessibility/dashboard
 sidebar: { order: 4 }
 ---
 
-import A11yBeta from "../../components/A11yBeta.astro";
-
 # Accessibility dashboard
-
-<A11yBeta />
 
 The Accessibility dashboard offers a comprehensive overview of accessibility issues in your components. Chromatic continuously monitors accessibility violations, enabling you to track compliance trends and prioritize remediation efforts effectively.
 

--- a/src/content/accessibilityTests/accessibility-usage.mdx
+++ b/src/content/accessibilityTests/accessibility-usage.mdx
@@ -6,11 +6,8 @@ sidebar: { order: 2 }
 ---
 
 import InstallSnippets from "../../components/InstallSnippets.astro";
-import A11yBeta from "../../components/A11yBeta.astro";
 
 # Set up and run accessibility tests
-
-<A11yBeta />
 
 This guide will walk you through setting up and using Chromatic's accessibility testing in your workflow. To get started, you need to have Chromatic set up for your Storybook project. If you haven't done this yet, follow the [quickstart guide](/docs/quickstart) to get started. And ensure that you are using Storybook version 6.5+ and have [Accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing) installed and enabled.
 

--- a/src/content/accessibilityTests/accessibility.mdx
+++ b/src/content/accessibilityTests/accessibility.mdx
@@ -4,11 +4,7 @@ description: Catch accessibility issues early with automated testing for your co
 sidebar: { order: 1 }
 ---
 
-import A11yBeta from "../../components/A11yBeta.astro";
-
 # Accessibility testing with Chromatic
-
-<A11yBeta />
 
 Chromatic builds on Storybook and [axe](https://github.com/dequelabs/axe-core) to seamlessly integrate accessibility testing into your development workflow. You write stories to create test cases for your components and run accessibility checks locally within Storybook.
 


### PR DESCRIPTION
With this pull request, the A11y beta callout was removed from the docs to prevent any issues.

What was done:
- Removed the A11y callout from the documentation

One quick item here, @winkerVSbecks: Do you still want to keep the component for the time being and retask it for other uses, or remove it?

Let me know and we can follow up on it