### PR TITLE
Docs: Update E2E images and node versions to latest

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -38,7 +38,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.18.0"
+                  version: "22.20.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -70,7 +70,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.55.0-noble
+            container: mcr.microsoft.com/playwright:v1.56.0-noble
             steps:
               - checkout: self
                 displayName: "Get Full Git History"
@@ -78,7 +78,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.18.0"
+                  version: "22.20.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -114,7 +114,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.18.0"
+                  version: "22.20.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -152,7 +152,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Cypress
             displayName: "Run Cypress"
-            container: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
+            container: cypress/browsers:node-22.20.0-chrome-141.0.7390.54-1-ff-143.0.4-edge-141.0.3537.57-1
             variables:
               npm_config_cache: $(Pipeline.Workspace)/.npm
             steps:
@@ -162,7 +162,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.18.0"
+                  version: "22.20.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -200,7 +200,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "22.18.0"
+                  version: "22.20.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -56,7 +56,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.55.0-noble
+                  image: mcr.microsoft.com/playwright:v1.56.0-noble
                   caches:
                     - npm
                     - node
@@ -95,7 +95,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - step:
                 name: "Cypress"
                 # Configure the ELECTRON_EXTRA_LAUNCH_ARGS environment variable in your project settings to run Cypress tests with Chromatic.
-                image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
+                image: cypress/browsers:node-22.20.0-chrome-141.0.7390.54-1-ff-143.0.4-edge-141.0.3537.57-1
                 caches:
                   - npm
                   - node

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -24,7 +24,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:22.18
+          - image: cimg/node:22.20.0
         working_directory: ~/repo
 
     jobs:
@@ -58,11 +58,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-noble-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.55.0-noble
+          - image: mcr.microsoft.com/playwright:v1.56.0-noble
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:22.18
+          - image: cimg/node:22.20.0
         working_directory: ~/repo
 
     jobs:
@@ -130,11 +130,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       cypress:
         docker:
-          - image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
+          - image: cypress/browsers:node-22.20.0-chrome-141.0.7390.54-1-ff-143.0.4-edge-141.0.3537.57-1
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:22.18
+          - image: cimg/node:22.20.0
         working_directory: ~/repo
 
     jobs:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -41,7 +41,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.55.0-noble
+        container: mcr.microsoft.com/playwright:v1.56.0-noble
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.
@@ -67,7 +67,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Cypress"
         displayName: "Run Cypress tests"
-        container: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
+        container: cypress/browsers:node-22.20.0-chrome-141.0.7390.54-1-ff-143.0.4-edge-141.0.3537.57-1
         environment:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         options:

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -34,7 +34,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.18.0
+              node-version: 22.20.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -55,14 +55,14 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.55.0-noble
+          image: mcr.microsoft.com/playwright:v1.56.0-noble
         steps:
           - uses: actions/checkout@v4
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.18.0
+              node-version: 22.20.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -88,7 +88,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.18.0
+              node-version: 22.20.0
           - name: Install dependencies
              # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -119,7 +119,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         name: Run Cypress
         runs-on: ubuntu-latest
         container:
-          image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
+          image: cypress/browsers:node-22.20.0-chrome-141.0.7390.54-1-ff-143.0.4-edge-141.0.3537.57-1
           options: --user 1001
         steps:
           - uses: actions/checkout@v4
@@ -127,7 +127,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.18.0
+              node-version: 22.20.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -155,7 +155,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               fetch-depth: 0
           - uses: actions/setup-node@v4
             with:
-              node-version: 22.18.0
+              node-version: 22.20.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -58,7 +58,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.55.0-noble
+      image: mcr.microsoft.com/playwright:v1.56.0-noble
       script:
         - npx playwright test
       allow_failure: true
@@ -98,7 +98,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Cypress:
       stage: UI_Tests
       needs: []
-      image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
+      image: cypress/browsers:node-22.20.0-chrome-141.0.7390.54-1-ff-143.0.4-edge-141.0.3537.57-1
       variables:
         ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
       script:

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -50,7 +50,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.55.0-noble'
+               image 'mcr.microsoft.com/playwright:v1.56.0-noble'
                reuseNode true
              }
            }
@@ -93,7 +93,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Cypress') {
            agent {
              docker {
-               image 'cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1'
+               image 'cypress/browsers:node-22.20.0-chrome-141.0.7390.54-1-ff-143.0.4-edge-141.0.3537.57-1'
                reuseNode true
              }
            }

--- a/src/content/ci/semaphore.mdx
+++ b/src/content/ci/semaphore.mdx
@@ -73,7 +73,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               os_image: ubuntu2204
             containers:
               - name: Plawyright
-                image: mcr.microsoft.com/playwright:v1.55.0-noble
+                image: mcr.microsoft.com/playwright:v1.56.0-noble
           jobs:
             - name: Run Playwright
               commands:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -26,14 +26,14 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0-noble
+      image: mcr.microsoft.com/playwright:v1.56.0-noble
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.18.0
+          node-version: 22.20.0
       - name: Install dependencies
         run: npm ci
       - name: Run Playwright tests
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.18.0
+          node-version: 22.20.0
       - name: Install dependencies
         run: npm ci
 
@@ -96,7 +96,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.55.0-noble
+  image: mcr.microsoft.com/playwright:v1.56.0-noble
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -122,10 +122,10 @@ version: 2.1
 executors:
   pw-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.55.0-noble
+      - image: mcr.microsoft.com/playwright:v1.56.0-noble
   chromatic-ui-testing:
     docker:
-      - image: cimg/node:22.18
+      - image: cimg/node:22.20.0
 
 jobs:
   Playwright:
@@ -200,7 +200,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.55.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.56.0-noble'
               reuseNode true
             }
           }
@@ -220,7 +220,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.55.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.56.0-noble'
               reuseNode true
             }
           }
@@ -278,7 +278,7 @@ blocks:
           os_image: ubuntu2204
         containers:
           - name: Plawyright
-            image: mcr.microsoft.com/playwright:v1.55.0-noble
+            image: mcr.microsoft.com/playwright:v1.56.0-noble
       jobs:
         - name: Run Playwright
           commands:
@@ -317,7 +317,7 @@ image: node:jod
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.55.0-noble
+    container: mcr.microsoft.com/playwright:v1.56.0-noble
     options:
       parallel: 2
       artifacts:


### PR DESCRIPTION
This pull request updated the E2E CI documentation to match the latest stable releases.

What was done:
- Updated the E2E CI examples to match the current stable versions (including the Docker images and node versions)

Going to self-merge this once the checklist clears
cc @winkerVSbecks 