### PR TITLE
Docs: Fix A11y project-level configuration example

### DIFF
--- a/src/content/accessibilityTests/accessibility-configure.mdx
+++ b/src/content/accessibilityTests/accessibility-configure.mdx
@@ -64,7 +64,7 @@ const preview: Preview = {
       options: {},
     },
   },
-  globals: {
+  initialGlobals: {
     a11y: {
       // Optional flag to prevent the automatic check within Storybook
       manual: true,


### PR DESCRIPTION
Addresses [#32731](https://github.com/storybookjs/storybook/issues/32731)

With this pull request, the A11y configuration example is updated to reflect the correct Storybook API (i.e., `initialGlobals`) usage when configuring the Storybook A11y addon at the project level.

What was done:
- Adjusted the example to use the correct API

@winkerVSbecks going to merge this once the checklist clears to get the documentation updated and published as soon as possible.