### PR TITLE
added notes to the workingDir flag

### DIFF
--- a/chromatic-config/options.json
+++ b/chromatic-config/options.json
@@ -302,11 +302,11 @@
   {
     "option": "workingDir",
     "flag": "--working-dir",
-    "description": "Provide the location of Storybook's `package.json` if installed in a subdirectory (i.e., monorepos).",
+    "description": "Provide the location of Storybook's `package.json` if installed in a subdirectory (i.e., monorepos). This is a GitHub Actions–specific key. Other CI/CD providers have their own flag.",
     "type": "string",
     "example": "`\"my-folder\"`",
     "default": "process.cwd()",
-    "supports": ["CLI", "GitHub Action"]
+    "supports": ["GitHub Action"]
   },
   {
     "option": "untraced",


### PR DESCRIPTION
Refer to this Linear: https://linear.app/chromaui/issue/CAP-3668/cli-setting-the-cwd-with-the-workingdir-flag-fails-on-cli-v1330#comment-ef28caeb

- Removed tag CLI as workingDir is GHA-specific, not on our code/CLI.
- More clarification about not using it for other CI providers.