### PR TITLE
Fix broken links

### DIFF
--- a/src/content/modes/modes.mdx
+++ b/src/content/modes/modes.mdx
@@ -89,7 +89,7 @@ export default preview;
 
 <div class="aside">
 
-The `options` configuration object is only available in Storybook 9. See the versioned Storybook documentation for the [viewport](https://storybook.js.org/docs/7/essentials/viewport) and [backgrounds](https://storybook.js.org/docs/7/essentials/backgrounds) for more information on configuring these addons.
+The `options` configuration object is only available in Storybook 9. See the versioned Storybook documentation for the [viewport](https://storybook.js.org/docs/essentials/viewport) and [backgrounds](https://storybook.js.org/docs/essentials/backgrounds) for more information on configuring these addons.
 
 </div>
 


### PR DESCRIPTION
Fix links broken by including `/7/` in the storybook link