### PR TITLE
Docs: Fix outdated Storybook links

### DIFF
--- a/src/content/accessibilityTests/accessibility-configure.mdx
+++ b/src/content/accessibilityTests/accessibility-configure.mdx
@@ -142,7 +142,7 @@ export const NonA11yStory: Story = {
 
 <div class="aside">
 
-For older versions of Storybook, use [a11y parameter](https://storybook.js.org/docs/7/writing-tests/accessibility-testing#how-to-disable-a11y-tests) instead.
+For older versions of Storybook, use the `a11y` parameter to disable accessibility tests. Refer to the [parameters documentation](/docs/config-with-story-params) to learn more about defining parameters.
 
 </div>
 

--- a/src/content/guides/guide-for-designers.md
+++ b/src/content/guides/guide-for-designers.md
@@ -22,7 +22,7 @@ Design and development naturally diverge. During the design process, you need to
 
 #### Documentation that's always up to date
 
-Documentation goes out of date quickly. Storybook and Chromatic work together to automatically [generate UI documentation](https://storybook.js.org/docs/writing-docs/introduction) and publish it to a shareable URL. This documentation contains stories rendered as live examples, as well as an interactive component API explorer. You can also customize the generated docs with additional prose. [Learn more »](/docs/document)
+Documentation goes out of date quickly. Storybook and Chromatic work together to automatically [generate UI documentation](https://storybook.js.org/docs/writing-docs) and publish it to a shareable URL. This documentation contains stories rendered as live examples, as well as an interactive component API explorer. You can also customize the generated docs with additional prose. [Learn more »](/docs/document)
 
 #### Embed stories in Notion and other oEmbed services
 

--- a/src/content/visualTests/visual-tests-addon.mdx
+++ b/src/content/visualTests/visual-tests-addon.mdx
@@ -49,7 +49,7 @@ Add visual tests to your project by installing `@chromatic-com/storybook`:
 
 <div class="aside">
 
-Storybook 7.6 and higher required. Read the [migration guide](https://storybook.js.org/docs/migration-guide) for help migrating Storybook versions.
+Storybook 7.6 and higher required. Read the [migration guide](https://storybook.js.org/docs/releases/migration-guide) for help migrating Storybook versions.
 
 </div>
 


### PR DESCRIPTION
With the release of Storybook 10, some documentation links were updated and/or removed due to infrastructure changes. This pull request aims to resolve this issue and prevent any further documentation issues.

What was done:
- Adjusted the A11y link to point to the Chromatic docs instead of the nonexistent Storybook documentation
- Fixed other misc links