### PR TITLE
Fix apostrophe-related typos in troubleshooting docs

### DIFF
--- a/src/content/snapshot/troubleshooting-snapshots.md
+++ b/src/content/snapshot/troubleshooting-snapshots.md
@@ -327,7 +327,7 @@ It's essential that your components and stories render in a **consistent** fashi
 
 - **Use of the current date/time**: Dates and times are a tester's bane! To get consistency in components or tests that use the current time, you can use a tool to also "seed" the time, like [mockdate](https://www.npmjs.com/package/mockdate) for the `Date` object.
 
-- **UI takes time to render**: UI can take extra time to "settle" into it's final orientation. Add a [delay](/docs/delay) to take a snapshot after waiting a period of time. Note that this technique can make the UI rendering inconsistency less obvious in snapshots, but it won't eliminate the underlying issue in how UI renders.
+- **UI takes time to render**: UI can take extra time to "settle" into its final orientation. Add a [delay](/docs/delay) to take a snapshot after waiting a period of time. Note that this technique can make the UI rendering inconsistency less obvious in snapshots, but it won't eliminate the underlying issue in how UI renders.
 
 - **Intentional randomness**: Some stories may render unpredictably intentionally. If this is the case you may want to [ignore the story](/docs/disable-snapshots#with-storybook) from UI Tests and move on.
   If you still need inconsistent elements for local development purposes inside Storybook, you can use `isChromatic()` exported from [our package](/docs/ischromatic) to apply the solutions above only when in the Chromatic environment.


### PR DESCRIPTION
Adding one apostrophe where it was missing and removing one where it was unnecessary.