### PR TITLE
Add Matt Gill to the security page for responsible disclosure

### DIFF
--- a/src/content/account/security.md
+++ b/src/content/account/security.md
@@ -23,6 +23,7 @@ Chromatic is grateful to the following individuals for responsibly disclosing se
 
 #### 2025
 
+- [Matt Gill](https://www.linkedin.com/in/mattagill)
 - [Mridul Rastogi](https://www.linkedin.com/in/mridul-rastogi-532726292/)
 - [Harsh Maheta](https://www.linkedin.com/in/harsh-maheta-7057542a9)
 - [Parth Narula](https://www.linkedin.com/in/parth-narula-86283821a)


### PR DESCRIPTION
He disclosed CVE-2025-68429.