### PR TITLE
Add FAQ for setting `ref` when using both `merge_group` and `pull_request` events

### DIFF
--- a/src/content/troubleshooting/faq/merge-queue-ref.mdx
+++ b/src/content/troubleshooting/faq/merge-queue-ref.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar: { hide: true }
 title: How should ref be configured for merge_group and pull_request builds?
-section: TurboSnap
+section: turboSnap
 ---
 
 # How should `ref` be configured for `merge_group` and `pull_request` builds?


### PR DESCRIPTION
Adding FAQ to TurboSnap section for setting the `ref` when triggering with both `pull_request` and `merge_group`.  