### PR TITLE
Feat: Updates Actions Node version to latest

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -11,12 +11,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
-
       - name: Get pnpm store directory
         shell: bash
         run: |
@@ -29,14 +27,11 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-
       - name: Install dependencies
         run: pnpm install
-
       - name: Check links
         id: check-links
         run: pnpm run check-links
-
       - name: Send failure status to slack
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.24.0

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,11 +12,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.18.0
-
+          node-version: 24.13.0
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
@@ -32,7 +30,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-
       - name: Install dependencies
         run: pnpm install
       - name: Run Chromatic

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,17 +11,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           run_install: false
-
       - name: Get pnpm store directory
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
       - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
@@ -29,7 +26,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-
       - name: Install dependencies
         run: pnpm install
       - name: Run Vitest


### PR DESCRIPTION
Follows up on #765. 

With this pull request, the Node version used in the Actions was bumped to the latest stable version (i.e., Node 24), as Node 22 as entered into maintenance mode late last year