### PR TITLE
Adding fix for same branch baseline reset

### DIFF
--- a/src/content/snapshot/branching-and-baselines.md
+++ b/src/content/snapshot/branching-and-baselines.md
@@ -185,9 +185,9 @@ Let's say you've made a change to a component on your `feature-branch`, accepted
   }
 }%%
 gitGraph TB:
+  checkout main
   commit id: "X" type: HIGHLIGHT
-  branch main
-  checkout feature-branch
+  branch feature-branch
   commit id: "A" tag: "unwanted changes"
   commit id: "B"
   commit id: "C" type: HIGHLIGHT


### PR DESCRIPTION
I've had multiple customers inquire about how they can reset without introducing a new branch if they're still working on their feature, so adding basic instructions for baseline reset on pre-merge/same branch. 