### PR TITLE
corrected links and typos

### DIFF
--- a/src/content/collaborate/access.md
+++ b/src/content/collaborate/access.md
@@ -373,8 +373,8 @@ If your organization restricts IP addresses for git access, make sure to [add Ch
 <details>
 <summary>Why am I getting an error when trying to access a GitHub SSO project that I see listed in Chromatic’s project list?</summary>
 
-This error can occur when Chromatic isn’t authorized for a GitHub organization that has SSO/SAML also configured. In order to grant access to a project, Chromatic uses that project’s token and your account’s GitHub token. During the login process for Chromatic you authenticate with GitHub and will be presented with a prompt inside of GitHub to authorize Chromatic for use in your organization.
+This error can occur when Chromatic isn't authorized for a GitHub organization that has SSO/SAML also configured. In order to grant access to a project, Chromatic uses that project’s token and your account’s GitHub token. During the login process for Chromatic you authenticate with GitHub and will be presented with a prompt inside of GitHub to authorize Chromatic for use in your organization.
 
-You must click the **Authorize** button. If you don’t click the **Authorize** button, but instead click the **Continue** button, you will not be able to access the project in Chromatic. If the person that set up the project previously logged into Chromatic with their GitHub credential but never authorized Chromatic for their organization, their teammates will also encounter this issue.
+You must click the **Authorize** button. If you don't click the **Authorize** button, but instead click the **Continue** button, you will not be able to access the project in Chromatic. If the person that set up the project previously logged into Chromatic with their GitHub credential but never authorized Chromatic for their organization, their teammates will also encounter this issue.
 
 </details>

--- a/src/content/cypress/configure.md
+++ b/src/content/cypress/configure.md
@@ -11,7 +11,7 @@ You can enhance your Cypress and Chromatic tests further by configuring them usi
 
 ## Cypress options
 
-Cypress can be configured with [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables). You can set the available options globally in your Cypress configuration file as follows:
+Cypress can be configured with [Cypress environment variables](https://docs.cypress.io/app/guides/environment-variables). You can set the available options globally in your Cypress configuration file as follows:
 
 ```ts title="cypress.config.js|ts"
 export default defineConfig({
@@ -23,7 +23,7 @@ export default defineConfig({
 });
 ```
 
-You can also override them for specific tests using via the [`env`](https://docs.cypress.io/guides/guides/environment-variables#Suite-of-test-configuration) option in the test configuration:
+You can also override them for specific tests using via the [`env`](https://docs.cypress.io/app/references/configuration#Suite-configuration) option in the test configuration:
 
 ```ts title="cypress/e2e/HomePage.cy.js|ts"
 describe("HomePage", () => {

--- a/src/content/playwright/configure.mdx
+++ b/src/content/playwright/configure.mdx
@@ -13,7 +13,7 @@ You can enhance your Playwright and Chromatic tests further by configuring them 
 
 ## Playwright options
 
-The Chromatic [Playwright Fixture](https://playwright.dev/docs-fixtures) can be configured with `use` like all [Playwright options](https://playwright.dev/docs-use-options). You can set the available options globally in your Playwright configuration file as follows:
+The Chromatic [Playwright Fixture](https://playwright.dev/docs/test-fixtures) can be configured with `use` like all [Playwright options](https://playwright.dev/docs/test-use-options). You can set the available options globally in your Playwright configuration file as follows:
 
 <Tabs>
   <TabItem label="TypeScript">

--- a/src/content/playwright/setup.mdx
+++ b/src/content/playwright/setup.mdx
@@ -219,7 +219,7 @@ Chromatic creates and runs a Storybook [archive](/docs/faq/what-is-archive) base
 <details>
 <summary id="third-party-integrations">Can I use custom fixtures with Playwright visual tests?</summary>
 
-Chromatic’s Playwright integration is designed to work with third-party integrations and tools. It allows you to combine your existing fixtures via the [`mergeTests`](https://playwright.dev/docs-fixtures#combine-custom-fixtures-from-multiple-modules) option. See our FAQ on [BDD support with Playwright](/docs/faq/bdd-with-playwright) to learn more.
+Chromatic’s Playwright integration is designed to work with third-party integrations and tools. It allows you to combine your existing fixtures via the [`mergeTests`](https://playwright.dev/docs/test-fixtures#combine-custom-fixtures-from-multiple-modules) option. See our FAQ on [BDD support with Playwright](/docs/faq/bdd-with-playwright) to learn more.
 
 </details>
 

--- a/src/content/snapshot/disable-snapshots.mdx
+++ b/src/content/snapshot/disable-snapshots.mdx
@@ -100,6 +100,6 @@ By default, Chromatic's Playwright and Cypress integrations run tests and captur
 <details>
 <summary>Why are disabled stories still listed?</summary>
 
-If you enable the `disabledSnapshot` configuration option to prevent your stories from being snapshotted, Chromatic will continue to index them and display them in the Library view. However, the "Snapshot" tab will no longer be visible in the UI for these stories. To remove the story altogether, you will need to delete it from your Storybook.
+If you enable the `disableSnapshot` configuration option to prevent your stories from being snapshotted, Chromatic will continue to index them and display them in the Library view. However, the "Snapshot" tab will no longer be visible in the UI for these stories. To remove the story altogether, you will need to delete it from your Storybook.
 
 </details>

--- a/src/content/troubleshooting/faq/junit-report-usage.mdx
+++ b/src/content/troubleshooting/faq/junit-report-usage.mdx
@@ -78,7 +78,7 @@ Stories that are skipped during the build are explicitly marked with a `<skipped
 
 A story that has passed successfully will appear as a simple `<testcase>` with no child tags.
 
-Stories that you've disabled in your Storybook configuration (`disabledSnapshot: true`) will still be listed in the report but will not be flagged with `<skipped/>`.
+Stories that you've disabled in your Storybook configuration (`disableSnapshot: true`) will still be listed in the report but will not be flagged with `<skipped/>`.
 
 ## Storing the Report as an Artifact
 


### PR DESCRIPTION
1. disabledSnapshot -> disableSnapshot

2. Playwright links changed. Links like https://playwright.dev/docs-fixtures are no longer valid, now `https://playwright.dev/docs/...`

3. Cypress updated too.