### PR TITLE
Address PR review feedback for llms.txt endpoints

### DIFF
--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -2,11 +2,10 @@ import type { APIRoute } from "astro";
 import { getAllDocs } from "../utils/collections";
 import { llmsFullTxt, docToFullItem } from "../utils/llms";
 
-const siteUrl = "https://www.chromatic.com";
-const baseUrl = import.meta.env.BASE_URL;
-const SITE = `${siteUrl}${baseUrl}`;
+export const GET: APIRoute = async ({ site, url }) => {
+  const baseUrl = import.meta.env.BASE_URL;
+  const SITE = new URL(baseUrl, site ?? url).href.replace(/\/$/, "");
 
-export const GET: APIRoute = async () => {
   const allDocs = await getAllDocs();
 
   return llmsFullTxt({
@@ -14,7 +13,6 @@ export const GET: APIRoute = async () => {
     description:
       "Chromatic is a cloud-based toolchain for visual testing, reviewing, and documenting Storybook components.",
     site: SITE,
-    sections: [],
     docs: allDocs.map((entry) => docToFullItem(entry, SITE)),
   });
 };

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -2,12 +2,11 @@ import type { APIRoute } from "astro";
 import { getDocSections } from "../utils/collections";
 import { llmsTxt, docToLlmsItem } from "../utils/llms";
 
-const siteUrl = "https://www.chromatic.com";
-const baseUrl = import.meta.env.BASE_URL;
-const SITE = `${siteUrl}${baseUrl}`;
-const LLMS_BASE = `${SITE}/llms`;
+export const GET: APIRoute = async ({ site, url }) => {
+  const baseUrl = import.meta.env.BASE_URL;
+  const base = new URL(baseUrl, site ?? url).href.replace(/\/$/, "");
+  const LLMS_BASE = `${base}/llms`;
 
-export const GET: APIRoute = async () => {
   const sections = await getDocSections();
 
   return llmsTxt({

--- a/src/pages/llms/[...slug].txt.ts
+++ b/src/pages/llms/[...slug].txt.ts
@@ -1,10 +1,10 @@
 import type { GetStaticPaths } from "astro";
 import { getAllDocs } from "../../utils/collections";
-import { llmsDoc } from "../../utils/llms";
+import { llmsDoc, type DocEntry } from "../../utils/llms";
 
-const siteUrl = "https://www.chromatic.com";
+const siteUrl = import.meta.env.SITE ?? "https://chromatic.com/docs";
 const baseUrl = import.meta.env.BASE_URL;
-const SITE = `${siteUrl}${baseUrl}`;
+const SITE = new URL(baseUrl, siteUrl).href.replace(/\/$/, "");
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const allDocs = await getAllDocs({ includeNotInNavigation: true });
@@ -15,6 +15,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }));
 };
 
-export const GET = ({ props }: { props: { doc: any } }) => {
+export const GET = ({ props }: { props: { doc: DocEntry } }) => {
   return llmsDoc(props.doc, SITE);
 };

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,4 +1,5 @@
 import { getCollection } from "astro:content";
+import type { DocEntry } from "./llms";
 
 export async function getAllCollections() {
   const [
@@ -114,7 +115,7 @@ export async function getDocSections() {
 
   // Track section order based on first appearance in sectionMap
   const sectionOrder: string[] = [];
-  const sectionItems: Record<string, any[]> = {};
+  const sectionItems: Record<string, DocEntry[]> = {};
 
   for (const [collectionName, sectionTitle] of sectionMap) {
     if (!sectionOrder.includes(sectionTitle)) {

--- a/src/utils/llms.test.ts
+++ b/src/utils/llms.test.ts
@@ -99,7 +99,6 @@ describe("llmsFullTxt", () => {
       name: "Test Site",
       description: "A test site",
       site: "https://example.com",
-      sections: [],
       docs: [
         {
           title: "First Doc",
@@ -132,7 +131,6 @@ describe("llmsFullTxt", () => {
       name: "Test",
       description: "Test",
       site: "https://example.com",
-      sections: [],
       docs: [
         {
           title: "MDX Doc",
@@ -146,8 +144,29 @@ describe("llmsFullTxt", () => {
     const text = await readResponse(response);
     expect(text).toContain("Regular markdown content.");
     expect(text).not.toContain("import Component");
+    expect(text).toContain("children");
     expect(text).not.toContain("<Component");
-    expect(text).not.toContain("<SelfClosing />");
+    expect(text).not.toContain("<SelfClosing");
+  });
+
+  test("preserves imports inside code fences", async () => {
+    const response = llmsFullTxt({
+      name: "Test",
+      description: "Test",
+      site: "https://example.com",
+      docs: [
+        {
+          title: "Code Doc",
+          description: "Has code",
+          link: "https://example.com/code",
+          body: 'import Foo from "./Foo";\n\nSome text.\n\n```ts\nimport { bar } from "baz";\nconsole.log(bar);\n```',
+        },
+      ],
+    });
+
+    const text = await readResponse(response);
+    expect(text).toContain('import { bar } from "baz";');
+    expect(text).not.toContain("import Foo");
   });
 });
 
@@ -162,6 +181,22 @@ describe("llmsDoc", () => {
     expect(text).toContain("URL: https://example.com/test-doc");
     expect(text).toContain("## Hello");
     expect(text).toContain("Some content here.");
+  });
+
+  test("uses site root URL for isHome entries", async () => {
+    const doc = mockDoc({
+      id: "introduction",
+      data: {
+        title: "Introduction",
+        description: "Welcome",
+        isHome: true,
+      },
+    });
+    const response = llmsDoc(doc, "https://example.com");
+
+    const text = await readResponse(response);
+    expect(text).toContain("URL: https://example.com");
+    expect(text).not.toContain("URL: https://example.com/introduction");
   });
 
   test("strips MDX from individual doc", async () => {
@@ -216,5 +251,19 @@ describe("docToFullItem", () => {
       link: "https://example.com/test-doc",
       body: "## Hello\n\nSome content here.",
     });
+  });
+
+  test("uses site root URL for isHome entries", () => {
+    const doc = mockDoc({
+      id: "introduction",
+      data: {
+        title: "Introduction",
+        description: "Welcome",
+        isHome: true,
+      },
+    });
+    const item = docToFullItem(doc, "https://example.com");
+
+    expect(item.link).toBe("https://example.com");
   });
 });

--- a/src/utils/llms.ts
+++ b/src/utils/llms.ts
@@ -94,8 +94,24 @@ function stripTopLevelImportsOutsideCodeFences(content: string): string {
 
 function stripMdx(content: string): string {
   const withoutImports = stripTopLevelImportsOutsideCodeFences(content);
+  const lines = withoutImports.split("\n");
 
-  return withoutImports.replace(MDX_COMPONENT_TAG, "").trim();
+  let inFence = false;
+  const processedLines = lines.map((line) => {
+    const isFence = line.trimStart().startsWith("```");
+    if (isFence) {
+      inFence = !inFence;
+      return line;
+    }
+
+    if (inFence) {
+      return line;
+    }
+
+    return line.replace(MDX_COMPONENT_TAG, "");
+  });
+
+  return processedLines.join("\n").trim();
 }
 
 function doc(...sections: (string | string[])[]): Response {

--- a/src/utils/llms.ts
+++ b/src/utils/llms.ts
@@ -5,7 +5,7 @@
  */
 import type { CollectionEntry } from "astro:content";
 
-type DocEntry =
+export type DocEntry =
   | CollectionEntry<"overview">
   | CollectionEntry<"visualTests">
   | CollectionEntry<"accessibilityTests">
@@ -44,21 +44,58 @@ interface LlmsFullTxtConfig {
   name: string;
   description: string;
   site: string;
-  sections: LlmsSection[];
   docs: { title: string; description: string; link: string; body: string }[];
 }
 
-const MDX_PATTERNS = [
-  /^import\s+.+from\s+['"].+['"];?\s*$/gm,
-  /<[A-Z][a-zA-Z]*[^>]*>[\s\S]*?<\/[A-Z][a-zA-Z]*>/g,
-  /<[A-Z][a-zA-Z]*[^>]*\/>/g,
-] as const;
+const MDX_COMPONENT_TAG = /<\/?[A-Z][\w]*(\s+[^>]*?)?>/g;
+
+function stripTopLevelImportsOutsideCodeFences(content: string): string {
+  const lines = content.split("\n");
+  const importPattern = /^import\s+.+from\s+['"].+['"];?\s*$/;
+
+  let inFence = false;
+  let seenNonImportOutsideFence = false;
+  const resultLines: string[] = [];
+
+  for (const line of lines) {
+    const fenceMatch = line.trimStart().startsWith("```");
+    if (fenceMatch) {
+      inFence = !inFence;
+      resultLines.push(line);
+      continue;
+    }
+
+    if (inFence) {
+      resultLines.push(line);
+      continue;
+    }
+
+    if (!seenNonImportOutsideFence) {
+      if (line.trim() === "") {
+        resultLines.push(line);
+        continue;
+      }
+
+      if (importPattern.test(line)) {
+        // Skip top-of-file MDX import line.
+        continue;
+      }
+
+      seenNonImportOutsideFence = true;
+      resultLines.push(line);
+      continue;
+    }
+
+    resultLines.push(line);
+  }
+
+  return resultLines.join("\n");
+}
 
 function stripMdx(content: string): string {
-  return MDX_PATTERNS.reduce(
-    (text, pattern) => text.replace(pattern, ""),
-    content,
-  ).trim();
+  const withoutImports = stripTopLevelImportsOutsideCodeFences(content);
+
+  return withoutImports.replace(MDX_COMPONENT_TAG, "").trim();
 }
 
 function doc(...sections: (string | string[])[]): Response {
@@ -71,6 +108,10 @@ function doc(...sections: (string | string[])[]): Response {
   return new Response(content + "\n", {
     headers: { "Content-Type": "text/plain; charset=utf-8" },
   });
+}
+
+function entryUrl(entry: DocEntry, site: string): string {
+  return entry.data.isHome ? site : `${site}/${entry.id}`;
 }
 
 export function llmsTxt(config: LlmsTxtConfig): Response {
@@ -122,7 +163,7 @@ export function llmsDoc(entry: DocEntry, site: string): Response {
     "",
     `> ${description || title}`,
     "",
-    `URL: ${site}/${entry.id}`,
+    `URL: ${entryUrl(entry, site)}`,
     "",
     stripMdx(entry.body ?? ""),
   );
@@ -143,7 +184,7 @@ export function docToFullItem(entry: DocEntry, siteLink: string) {
   return {
     title: entry.data.title,
     description: entry.data.description || entry.data.title,
-    link: `${siteLink}/${entry.id}`,
+    link: entryUrl(entry, siteLink),
     body: entry.body ?? "",
   };
 }


### PR DESCRIPTION
## Summary
- Fix MDX stripping to only remove top-of-file imports (preserving `import` lines inside code fences) and strip JSX tags while keeping child content
- Handle `isHome: true` entries correctly by emitting the site root URL instead of a 404 path like `/docs/introduction`
- Derive site URL from Astro's configured `site` context instead of hardcoding `https://www.chromatic.com`
- Improve type safety: remove `any` from page route props and collection utilities, export `DocEntry` type, remove unused `sections` field from `LlmsFullTxtConfig`
- Add tests for `isHome` URL handling and imports inside code fences

## Test plan
- [x] All 13 unit tests pass (`vitest run src/utils/llms.test.ts`)
- [x] Verify `llms.txt`, `llms-full.txt`, and `llms/[slug].txt` endpoints render correctly in dev/build

🤖 Generated with [Claude Code](https://claude.com/claude-code)