### PR TITLE
docs: dead link on Playwright setup

### DIFF
--- a/src/content/playwright/setup.mdx
+++ b/src/content/playwright/setup.mdx
@@ -103,7 +103,7 @@ test("Homepage", async ({ page }) => {
 
 Run your Playwright tests as you normally would.
 
-While your Playwright tests are running, Chromatic captures an [archive](/docs/playwright#what-is-an-archive) of your app’s UI for each test.
+While your Playwright tests are running, Chromatic captures an [archive](/docs/faq/what-is-archive#what-is-an-archive) of your app’s UI for each test.
 
 {/* prettier-ignore-start */}
 


### PR DESCRIPTION
On https://www.chromatic.com/docs/playwright/#4-run-playwright there is dead link pointing at https://www.chromatic.com/docs/playwright#what-is-an-archive while it should point at https://www.chromatic.com/docs/faq/what-is-archive/.