### PR TITLE
Add new CLI config options for React Native

### DIFF
--- a/chromatic-config/generate-schema.test.ts
+++ b/chromatic-config/generate-schema.test.ts
@@ -217,6 +217,57 @@ describe("Generate Schema", () => {
     });
   });
 
+  test("Handles nested object options", async () => {
+    const options: ConfigOption[] = [
+      {
+        option: "reactNative",
+        description: "React Native–specific configuration options.",
+        type: "object",
+        example: "",
+        supports: ["Config File"],
+        options: [
+          {
+            option: "iosBuildCommand",
+            description:
+              "The command that builds your React Native Storybook for iOS.",
+            type: "string",
+            example: '`"nx run my-app:build-storybook-ios"`',
+            supports: ["Config File"],
+          },
+        ],
+      },
+    ];
+
+    const schema = await createSchemaDef(options);
+
+    expect(schema).toEqual({
+      ...schemaBase,
+      properties: {
+        $schema: {
+          type: "string",
+          description:
+            "The schema file (https://www.chromatic.com/docs/chromatic-config.schema.json)",
+        },
+        reactNative: {
+          type: "object",
+          additionalProperties: false,
+          description: "React Native\u2013specific configuration options.",
+          markdownDescription:
+            "React Native\u2013specific configuration options.\n",
+          properties: {
+            iosBuildCommand: {
+              type: "string",
+              description:
+                "The command that builds your React Native Storybook for iOS.",
+              markdownDescription:
+                "The command that builds your React Native Storybook for iOS.\n",
+            },
+          },
+        },
+      },
+    });
+  });
+
   test("Makes relative links absolute", async () => {
     const options: ConfigOption[] = [
       {

--- a/chromatic-config/generate-schema.ts
+++ b/chromatic-config/generate-schema.ts
@@ -6,6 +6,17 @@ import optionsJSON from "./options.json" assert { type: "json" };
 
 export type SupportedType = "GitHub Action" | "CLI" | "Config File";
 
+export interface NestedConfigOption {
+  option: string;
+  description: string;
+  type: string | string[];
+  example: string;
+  default?: string | boolean;
+  defaultComment?: string;
+  deprecated?: "Config File" | "all";
+  supports: SupportedType[];
+}
+
 export interface ConfigOption {
   option?: string;
   flag?: string;
@@ -17,6 +28,7 @@ export interface ConfigOption {
   defaultComment?: string;
   deprecated?: "Config File" | "all";
   supports: SupportedType[];
+  options?: NestedConfigOption[];
 }
 
 const propertyTypes = {
@@ -124,23 +136,49 @@ export async function createSchemaDef(configOptions: ConfigOption[]) {
       );
       const plainTextDescription = stripMarkdown(description);
 
-      const type = (
-        Array.isArray(prop.type) ? prop.type.join("-") : prop.type
-      ) as PropertyType;
+      let propDef: Record<string, unknown>;
 
-      const propDef = {
-        ...propertyTypes[type],
-        ...(isDeprecated && { deprecated: true }),
-        description: plainTextDescription,
-        markdownDescription: description,
-        ...(prop.default &&
-          prop.default !== "" && {
-            default:
-              typeof prop.default === "string"
-                ? stripMarkdown(prop.default)
-                : prop.default,
-          }),
-      };
+      if (prop.type === "object" && prop.options) {
+        const nestedProperties: Record<string, unknown> = {};
+        for (const subOption of prop.options) {
+          const subType = (
+            Array.isArray(subOption.type)
+              ? subOption.type.join("-")
+              : subOption.type
+          ) as PropertyType;
+          const subDescription = await formatDescription(subOption.description);
+          const subPlainText = stripMarkdown(subDescription);
+          nestedProperties[subOption.option] = {
+            ...propertyTypes[subType],
+            description: subPlainText,
+            markdownDescription: subDescription,
+          };
+        }
+        propDef = {
+          type: "object",
+          additionalProperties: false,
+          description: plainTextDescription,
+          markdownDescription: description,
+          properties: nestedProperties,
+        };
+      } else {
+        const type = (
+          Array.isArray(prop.type) ? prop.type.join("-") : prop.type
+        ) as PropertyType;
+        propDef = {
+          ...propertyTypes[type],
+          ...(isDeprecated && { deprecated: true }),
+          description: plainTextDescription,
+          markdownDescription: description,
+          ...(prop.default &&
+            prop.default !== "" && {
+              default:
+                typeof prop.default === "string"
+                  ? stripMarkdown(prop.default)
+                  : prop.default,
+            }),
+        };
+      }
 
       if (schemaDef.properties[prop.option]) {
         throw new Error(

--- a/chromatic-config/options.json
+++ b/chromatic-config/options.json
@@ -351,5 +351,27 @@
     "example": "`true`",
     "default": false,
     "supports": ["CLI", "GitHub Action", "Config File"]
+  },
+  {
+    "option": "reactNative",
+    "description": "React Native–specific configuration options.",
+    "type": "object",
+    "supports": ["Config File"],
+    "options": [
+      {
+        "option": "iosBuildCommand",
+        "description": "The command that builds your React Native Storybook for iOS.",
+        "type": "string",
+        "example": "`\"nx run my-app:build-storybook-ios\"`",
+        "supports": ["Config File"]
+      },
+      {
+        "option": "androidBuildCommand",
+        "description": "The command that builds your React Native Storybook for Android.",
+        "type": "string",
+        "example": "`\"nx run my-app:build-storybook-android\"`",
+        "supports": ["Config File"]
+      }
+    ]
   }
 ]

--- a/src/components/ConfigurationOptions/ConfigurationOptions.astro
+++ b/src/components/ConfigurationOptions/ConfigurationOptions.astro
@@ -1,12 +1,23 @@
 ---
-import type { ConfigOption as ConfigOptionType } from '../../../chromatic-config/generate-schema';
-import configOptions from '../../../chromatic-config/options.json';
-import { FilterableConfigOptions } from './FilterableConfigOptions';
-import { formatOption } from './formatOptions';
+import type { ConfigOption as ConfigOptionType } from "../../../chromatic-config/generate-schema";
+import configOptions from "../../../chromatic-config/options.json";
+import { FilterableConfigOptions } from "./FilterableConfigOptions";
+import { formatOption } from "./formatOptions";
 
-const formattedOptions = await Promise.all(
-  (configOptions as ConfigOptionType[]).map(formatOption)
-);
+const flatOptions = (configOptions as ConfigOptionType[]).flatMap((option) => {
+  if (option.options && option.options.length > 0) {
+    return option.options.map(
+      (subOption) =>
+        ({
+          ...subOption,
+          option: `${option.option}.${subOption.option}`,
+        }) as ConfigOptionType,
+    );
+  }
+  return [option];
+});
+
+const formattedOptions = await Promise.all(flatOptions.map(formatOption));
 ---
 
 <FilterableConfigOptions client:load options={formattedOptions} />


### PR DESCRIPTION
We are adding optional build commands for iOS and Android, and they are config file only.

I added them as a nested option under `reactNative`

See also chromaui/chromatic-cli#1289