### PR TITLE
Add URL encoding guidance for branch links

### DIFF
--- a/src/content/collaborate/publish.md
+++ b/src/content/collaborate/publish.md
@@ -24,6 +24,10 @@ When you're linking to a library or component on Chromatic, it can be useful to 
 
 **Example**: `https://www.chromatic.com/library?appId=...&branch=main`.
 
+<div class="aside">
+  If your branch name contains special characters like slashes or dots, URL-encode them in the query parameter. For example, <code>feature/my-branch</code> becomes <code>?branch=feature%2Fmy-branch</code>.
+</div>
+
 ## Embedding
 
 If you're documenting components outside of Storybook, you may be able to [embed interactive stories](/docs/embed). This works on many platforms that support the oEmbed specification.


### PR DESCRIPTION
## Summary

This PR adds a short note to the publishing docs explaining that branch names used in Chromatic library and component links should be URL-encoded when they contain special characters.

The page already showed how to add a `branch` query parameter for links such as `?branch=main`, but it did not explain what to do with real-world branch names like `feature/my-branch`. Since `/` has URL semantics, an unencoded branch value can produce confusing or broken links for users trying to share a specific branch view.

The fix adds an aside next to the existing branch query example and gives a concrete before/after: `feature/my-branch` becomes `?branch=feature%2Fmy-branch`.

## Testing

- `pnpm build`
