### PR TITLE
Docs: Bump CI and E2E to latest versions

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -38,7 +38,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.14.0"
+                  version: "24.15.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -70,7 +70,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.58.2-noble
+            container: mcr.microsoft.com/playwright:v1.60.0-noble
             steps:
               - checkout: self
                 displayName: "Get Full Git History"
@@ -78,7 +78,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.14.0"
+                  version: "24.15.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -114,7 +114,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.14.0"
+                  version: "24.15.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -152,7 +152,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Cypress
             displayName: "Run Cypress"
-            container: cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1
+            container: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
             variables:
               npm_config_cache: $(Pipeline.Workspace)/.npm
             steps:
@@ -162,7 +162,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.14.0"
+                  version: "24.15.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -200,7 +200,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.14.0"
+                  version: "24.15.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -56,7 +56,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.58.2-noble
+                  image: mcr.microsoft.com/playwright:v1.60.0-noble
                   caches:
                     - npm
                     - node
@@ -95,7 +95,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - step:
                 name: "Cypress"
                 # Configure the ELECTRON_EXTRA_LAUNCH_ARGS environment variable in your project settings to run Cypress tests with Chromatic.
-                image: cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1
+                image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
                 caches:
                   - npm
                   - node

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -24,7 +24,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.14.0
+          - image: cimg/node:24.15.0
         working_directory: ~/repo
 
     jobs:
@@ -58,11 +58,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-noble-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.58.2-noble
+          - image: mcr.microsoft.com/playwright:v1.60.0-noble
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.14.0
+          - image: cimg/node:24.15.0
         working_directory: ~/repo
 
     jobs:
@@ -130,11 +130,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       cypress:
         docker:
-          - image: cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1
+          - image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.14.0
+          - image: cimg/node:24.15.0
         working_directory: ~/repo
 
     jobs:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -41,7 +41,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.58.2-noble
+        container: mcr.microsoft.com/playwright:v1.60.0-noble
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.
@@ -67,7 +67,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Cypress"
         displayName: "Run Cypress tests"
-        container: cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1
+        container: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
         environment:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         options:

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -93,7 +93,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
              # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
           - name: Download Playwright test results
-            uses: actions/download-artifact@v4
+            uses: actions/download-artifact@v8
             with:
               name: test-results
               path: ./test-results
@@ -160,7 +160,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
           - name: Download Cypress test results
-            uses: actions/download-artifact@v4
+            uses: actions/download-artifact@v8
             with:
               name: test-results
               path: ./cypress/downloads

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -29,12 +29,12 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v5
+            uses: actions/checkout@v6
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.14.0
+              node-version: 24.15.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -55,14 +55,14 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.58.2-noble
+          image: mcr.microsoft.com/playwright:v1.60.0-noble
         steps:
-          - uses: actions/checkout@v5
+          - uses: actions/checkout@v6
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.14.0
+              node-version: 24.15.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -70,7 +70,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
             run: npx playwright test
             env:
               HOME: /root
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@v7
             if: always()
             with:
               # Chromatic automatically defaults to the test-results directory.
@@ -83,12 +83,12 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         needs: playwright
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v5
+          - uses: actions/checkout@v6
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.14.0
+              node-version: 24.15.0
           - name: Install dependencies
              # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -119,15 +119,15 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         name: Run Cypress
         runs-on: ubuntu-latest
         container:
-          image: cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1
+          image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
           options: --user 1001
         steps:
-          - uses: actions/checkout@v5
+          - uses: actions/checkout@v6
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.14.0
+              node-version: 24.15.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -137,7 +137,7 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
               ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
             with:
               start: npm run dev
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@v7
             with:
               # Chromatic automatically defaults to the cypress/downloads directory.
               # Replace with the path to your custom directory and adjust the CHROMATIC_ARCHIVE_LOCATION environment variable accordingly.
@@ -150,12 +150,12 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v5
+            uses: actions/checkout@v6
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.14.0
+              node-version: 24.15.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -507,7 +507,7 @@ This means the latest build on main will be an ancestor of this ephemeral branch
 If you decide to use the `pull_request` event, we recommend creating a separate workflow for Chromatic using the following strategy for the checkout step:
 
 ```yml
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
   with:
     fetch-depth: 0
     # 👇 Tells the checkout which commit hash to reference

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -58,7 +58,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
       script:
         - npx playwright test
       allow_failure: true
@@ -98,7 +98,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Cypress:
       stage: UI_Tests
       needs: []
-      image: cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1
+      image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
       variables:
         ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
       script:

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -50,7 +50,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.58.2-noble'
+               image 'mcr.microsoft.com/playwright:v1.60.0-noble'
                reuseNode true
              }
            }
@@ -93,7 +93,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Cypress') {
            agent {
              docker {
-               image 'cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1'
+               image 'cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1'
                reuseNode true
              }
            }

--- a/src/content/ci/semaphore.mdx
+++ b/src/content/ci/semaphore.mdx
@@ -31,6 +31,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     global_job_config:
       prologue:
         commands:
+          - sem-version node 24.15.0
           - checkout
 
     blocks:
@@ -73,7 +74,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               os_image: ubuntu2404
             containers:
               - name: Plawyright
-                image: mcr.microsoft.com/playwright:v1.58.2-noble
+                image: mcr.microsoft.com/playwright:v1.60.0-noble
           jobs:
             - name: Run Playwright
               commands:
@@ -121,6 +122,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     global_job_config:
       prologue:
         commands:
+          - sem-version node 24.15.0
           - checkout
 
     blocks:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -26,21 +26,21 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.14.0
+          node-version: 24.15.0
       - name: Install dependencies
         run: npm ci
       - name: Run Playwright tests
         run: npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           HOME: /root
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-${{ matrix.shard }}_${{ strategy.job-total }}
@@ -52,12 +52,12 @@ jobs:
     needs: playwright
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.14.0
+          node-version: 24.15.0
       - name: Install dependencies
         run: npm ci
 
@@ -96,7 +96,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.58.2-noble
+  image: mcr.microsoft.com/playwright:v1.60.0-noble
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -122,10 +122,10 @@ version: 2.1
 executors:
   pw-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.58.2-noble
+      - image: mcr.microsoft.com/playwright:v1.60.0-noble
   chromatic-ui-testing:
     docker:
-      - image: cimg/node:24.14.0
+      - image: cimg/node:24.15.0
 
 jobs:
   Playwright:
@@ -200,7 +200,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.58.2-noble'
+              image 'mcr.microsoft.com/playwright:v1.60.0-noble'
               reuseNode true
             }
           }
@@ -220,7 +220,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.58.2-noble'
+              image 'mcr.microsoft.com/playwright:v1.60.0-noble'
               reuseNode true
             }
           }
@@ -278,7 +278,7 @@ blocks:
           os_image: ubuntu2404
         containers:
           - name: Plawyright
-            image: mcr.microsoft.com/playwright:v1.58.2-noble
+            image: mcr.microsoft.com/playwright:v1.60.0-noble
       jobs:
         - name: Run Playwright
           commands:
@@ -317,7 +317,7 @@ image: node:krypton
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.58.2-noble
+    container: mcr.microsoft.com/playwright:v1.60.0-noble
     options:
       parallel: 2
       artifacts:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -62,7 +62,7 @@ jobs:
         run: npm ci
 
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./test-results/chromatic-archives
           pattern: playwright-report-*

--- a/src/content/troubleshooting/faq/chromatic-draft-pr.mdx
+++ b/src/content/troubleshooting/faq/chromatic-draft-pr.mdx
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # 👇 Makes sure Chromatic can review the full git history
           fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.14.0
+          node-version: 24.15.0
       # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
       - name: Install dependencies
         run: npm ci

--- a/src/content/troubleshooting/faq/chromatic-ui-related-commits.mdx
+++ b/src/content/troubleshooting/faq/chromatic-ui-related-commits.mdx
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24.14.0
+          node-version: 24.15.0
       - name:
           Install dependencies
           # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.

--- a/src/content/troubleshooting/faq/junit-report-usage.mdx
+++ b/src/content/troubleshooting/faq/junit-report-usage.mdx
@@ -86,7 +86,7 @@ First, ensure you're saving the report in your CI environment. In GitHub Actions
 
 ```yml title=".github/workflows/chromatic.yml"
 - name: Upload Build Report
-  uses: actions/upload-artifact@v4
+  uses: actions/upload-artifact@v7
   with:
     name: chromatic-reports
     path: chromatic-build-*.xml
@@ -101,7 +101,6 @@ Once you have the XML file, you can write a script in your CI pipeline to:
 ### Datadog
 
 The most straightforward method for sending your JUnit reports to Datadog is by using the `datadog-ci` command-line tool or its corresponding GitHub Action.
-
 
 1. Install the `datadog-ci` CLI
 2. After your tests have run and generated the JUnit XML report, use the following command:

--- a/src/content/troubleshooting/faq/merge-queue-ref.mdx
+++ b/src/content/troubleshooting/faq/merge-queue-ref.mdx
@@ -12,7 +12,7 @@ Here's an example of the checkout step:
 
 ```yml title=".github/workflows/chromatic.yml"
 steps:
-  - uses: actions/checkout@v5
+  - uses: actions/checkout@v6
     with:
       fetch-depth: 0
       ref: ${{ github.event.pull_request.head.ref || github.sha }}

--- a/src/content/turbosnap/turbosnap-best-practices.md
+++ b/src/content/turbosnap/turbosnap-best-practices.md
@@ -73,7 +73,7 @@ We recommend running Chromatic on `push` events. However, if you wish to trigger
 Create a separate workflow for Chromatic using the following strategy for the checkout step:
 
 ```yaml
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
   with:
     # 👇 Ensures Chromatic can read your full git history
     fetch-depth: 0


### PR DESCRIPTION
With this pull request all of the CI examples were updated to the latest versions, including Playwright and Cypress

What was done:
- Updated Node versions to the latest stable version
- Updated Playwright image to the latest versions
- Updated Cypress to the latest versions
- Updated GitHub Actions options to the latest versions

One small caveat to this. It wasn't automatically generated by AI, as the available SKILL will require some changes to be useful. That will be in a separate pull request.

cc @winkerVSbecks 