### PR TITLE
Require Plain auth after fallback

### DIFF
--- a/src/components/PlainChat.astro
+++ b/src/components/PlainChat.astro
@@ -109,6 +109,6 @@ import {
       console.warn('[plain] Failed to fetch customer details', error);
     }
 
-    window.Plain.init(BASE_CONFIG);
+    window.Plain.init({ ...BASE_CONFIG, requireAuthentication: true });
   })();
 </script>


### PR DESCRIPTION
## Summary

- Fixes [TOO-153](https://linear.app/chromaui/issue/TOO-153/fallback-built-in-auth-for-docs).
- Follows the monorepo precedent from [chromaui/chromatic#11303](https://github.com/chromaui/chromatic/pull/11303).
- Context: [Slack thread](https://chromaticqa.slack.com/archives/C0AK7QJ3T0X/p1779904771963629?thread_ts=1779904536.001459&cid=C0AK7QJ3T0X).
- Keeps successful manual Plain `customerDetails` auth for logged-in users.
- Falls back to Plain built-in email verification (`requireAuthentication: true`) when docs cannot fetch customer details.

## How to QA

- Run `pnpm build`.
- In a Plain-enabled local or review app, open docs chat while logged out/incognito and confirm Plain prompts for email verification before starting chat.
- Open docs chat while logged in and confirm the user still comes through via manual `customerDetails` auth.
