### PR TITLE
Fix IS_CHROMATIC env var to use STORYBOOK_ prefix

### DIFF
--- a/src/content/configuration/ischromatic.md
+++ b/src/content/configuration/ischromatic.md
@@ -62,17 +62,17 @@ export const Default: Story = {
 
 ## Environment variables
 
-If you're running Storybook tests with version 7.6 or higher, you can also use the `IS_CHROMATIC` environment variable to control how your tests run in Chromatic. To do so, adjust your `chromatic` script in your `package.json` file to include the environment variable as follows:
+If you're running Storybook tests with version 7.6 or higher, you can also use the `STORYBOOK_IS_CHROMATIC` environment variable to control how your tests run in Chromatic. To do so, adjust your `chromatic` script in your `package.json` file to include the environment variable as follows:
 
 ```json title="package.json"
 {
   "scripts": {
-    "chromatic": "IS_CHROMATIC=true chromatic"
+    "chromatic": "STORYBOOK_IS_CHROMATIC=true chromatic"
   }
 }
 ```
 
-Then, in your tests, you can check for the `IS_CHROMATIC` environment variable and set the available options accordingly (e.g., [args](https://storybook.js.org/docs/writing-stories/args), [parameters](https://storybook.js.org/docs/writing-stories/parameters)).
+Then, in your tests, you can check for the `STORYBOOK_IS_CHROMATIC` environment variable and set the available options accordingly (e.g., [args](https://storybook.js.org/docs/writing-stories/args), [parameters](https://storybook.js.org/docs/writing-stories/parameters)).
 
 ```ts title="MyComponent.stories.ts|tsx"
 // Adjust this import to match your framework (e.g., nextjs, vue3-vite)
@@ -90,14 +90,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    label: process.env.IS_CHROMATIC ? "I'm in Chromatic" : 'Not in Chromatic',
+    label: process.env.STORYBOOK_IS_CHROMATIC ? "I'm in Chromatic" : 'Not in Chromatic',
   },
 };
 ```
 
 <div class="aside">
 
-ℹ️ For Vite-based environments, you may be required to adjust your test to allow it to access the environment variable. See the [Vite documentation](https://vitejs.dev/guide/env-and-mode.html) for more information.
+ℹ️ Storybook only exposes environment variables prefixed with `STORYBOOK_` to the browser bundle. Using a non-prefixed variable like `IS_CHROMATIC` will not be accessible via `process.env` in your stories. For Vite-based environments, you may also need to adjust your configuration to allow access to environment variables. See the [Vite documentation](https://vitejs.dev/guide/env-and-mode.html) for more information.
 
 </div>
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updates the environment variables section of the `isChromatic` docs to use `STORYBOOK_IS_CHROMATIC` instead of `IS_CHROMATIC`
- Adds a clarifying note explaining that Storybook only exposes env vars prefixed with `STORYBOOK_` to the browser bundle

## Context

Storybook requires env vars to be prefixed with `STORYBOOK_` to be accessible via `process.env` in stories. The previous docs instructed users to set `IS_CHROMATIC=true`, which would never work as expected in story files.

Fixes #699

## Test plan

- [x] Verify the docs page at `/docs/ischromatic/` shows `STORYBOOK_IS_CHROMATIC` throughout the environment variables section
- [x] Verify the clarifying note appears below the code examples

https://claude.ai/code/session_016ut5LTRyfVsHkg6ryr1TcV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ut5LTRyfVsHkg6ryr1TcV)_