### PR TITLE
Add gitTimeout configuration option

### DIFF
--- a/chromatic-config/generate-schema.test.ts
+++ b/chromatic-config/generate-schema.test.ts
@@ -261,6 +261,41 @@ describe('Generate Schema', () => {
     });
   });
 
+  test('Handles number type with minimum and default', async () => {
+    const options: ConfigOption[] = [
+      {
+        option: 'gitTimeout',
+        description: 'The maximum number of seconds Chromatic waits for git operations.',
+        type: 'number',
+        example: '`30`',
+        default: 20,
+        minimum: 1,
+        supports: ['Config File'],
+      },
+    ];
+
+    const schema = await createSchemaDef(options);
+
+    expect(schema).toEqual({
+      ...schemaBase,
+      properties: {
+        $schema: {
+          type: 'string',
+          description:
+            'The schema file (https://www.chromatic.com/docs/chromatic-config.schema.json)',
+        },
+        gitTimeout: {
+          type: 'number',
+          minimum: 1,
+          default: 20,
+          description: 'The maximum number of seconds Chromatic waits for git operations.',
+          markdownDescription:
+            'The maximum number of seconds Chromatic waits for git operations.\n',
+        },
+      },
+    });
+  });
+
   test('Makes relative links absolute', async () => {
     const options: ConfigOption[] = [
       {

--- a/chromatic-config/generate-schema.ts
+++ b/chromatic-config/generate-schema.ts
@@ -11,8 +11,9 @@ export interface NestedConfigOption {
   description: string;
   type: string | string[];
   example: string;
-  default?: string | boolean;
+  default?: string | boolean | number;
   defaultComment?: string;
+  minimum?: number;
   deprecated?: 'Config File' | 'all';
   supports: SupportedType[];
 }
@@ -24,8 +25,9 @@ export interface ConfigOption {
   description: string;
   type: string | string[];
   example: string;
-  default?: string | boolean;
+  default?: string | boolean | number;
   defaultComment?: string;
+  minimum?: number;
   deprecated?: 'Config File' | 'all';
   supports: SupportedType[];
   options?: NestedConfigOption[];
@@ -40,6 +42,9 @@ const propertyTypes = {
   },
   glob: {
     type: 'string',
+  },
+  number: {
+    type: 'number',
   },
   string: {
     type: 'string',
@@ -155,6 +160,7 @@ export async function createSchemaDef(configOptions: ConfigOption[]) {
         propDef = {
           ...propertyTypes[type],
           ...(isDeprecated && { deprecated: true }),
+          ...(prop.minimum !== undefined && { minimum: prop.minimum }),
           description: plainTextDescription,
           markdownDescription: description,
           ...(prop.default &&

--- a/chromatic-config/options.json
+++ b/chromatic-config/options.json
@@ -117,6 +117,15 @@
     "supports": ["CLI", "GitHub Action"]
   },
   {
+    "option": "gitTimeout",
+    "description": "The maximum number of seconds Chromatic waits for individual git operations to complete before timing out. Increase this value if you have a large repository where git commands take longer than usual.",
+    "type": "number",
+    "example": "`30`",
+    "default": 20,
+    "minimum": 1,
+    "supports": ["Config File"]
+  },
+  {
     "option": "ignoreLastBuildOnBranch",
     "flag": "--ignore-last-build-on-branch",
     "description": "Do not use the last build on this branch as a baseline if it is no longer in history (i.e., the branch was rebased).",

--- a/chromatic-config/validate-schema.ts
+++ b/chromatic-config/validate-schema.ts
@@ -57,6 +57,7 @@ export async function validateSchema() {
     debug: true,
     diagnosticsFile: false,
     fileHashing: true,
+    gitTimeout: 30,
     junitReport: true,
     zip: true,
     autoAcceptChanges: 'main',


### PR DESCRIPTION
## Summary

Documents the new `gitTimeout` configuration option introduced in chromatic-cli [v17.3.0](https://github.com/chromaui/chromatic-cli/releases/tag/v17.3.0).

- **Purpose:** Controls the maximum time Chromatic waits for individual git operations before timing out.
- **Units:** Seconds (not milliseconds).
- **Default:** `20` seconds.
- **Minimum:** `1` second (cannot be `0` or negative).
- **Availability:** Config file only (no CLI flag / GitHub Action input), matching the CLI implementation.

## Changes

- Added the `gitTimeout` entry to `chromatic-config/options.json` (the source of truth that drives both the rendered docs and the generated JSON schema).
- Extended the schema generator (`generate-schema.ts`) with:
  - A `number` property type.
  - Support for an optional `minimum` constraint on options, emitted into the generated JSON schema so editors can validate the `>= 1` rule.
- Added a unit test covering the `number` type with `minimum` and `default`.
- Added `gitTimeout` to the exhaustive schema validation fixture.

## Testing

- `pnpm test:unit` — all 45 tests pass.
- Schema generation + validation runs cleanly during build (`✅ Exhaustive instance is valid`), and the generated schema contains `gitTimeout` with `type: number`, `minimum: 1`, and `default: 20`.

https://claude.ai/code/session_018FQyp4EjAzajfqXrqqoFe9

---
_Generated by [Claude Code](https://claude.ai/code/session_018FQyp4EjAzajfqXrqqoFe9)_