### PR TITLE
chore: upgrade CI code example versions to latest provider versions (playwright, cypress, vitest and node)

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -38,7 +38,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.15.0"
+                  version: "24.18.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -70,7 +70,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.60.0-noble
+            container: mcr.microsoft.com/playwright:v1.61.1-noble
             steps:
               - checkout: self
                 displayName: "Get Full Git History"
@@ -78,7 +78,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.15.0"
+                  version: "24.18.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -114,7 +114,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.15.0"
+                  version: "24.18.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -152,7 +152,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Cypress
             displayName: "Run Cypress"
-            container: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
+            container: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
             variables:
               npm_config_cache: $(Pipeline.Workspace)/.npm
             steps:
@@ -162,7 +162,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.15.0"
+                  version: "24.18.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -200,7 +200,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.15.0"
+                  version: "24.18.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -56,7 +56,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.60.0-noble
+                  image: mcr.microsoft.com/playwright:v1.61.1-noble
                   caches:
                     - npm
                     - node
@@ -95,7 +95,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - step:
                 name: "Cypress"
                 # Configure the ELECTRON_EXTRA_LAUNCH_ARGS environment variable in your project settings to run Cypress tests with Chromatic.
-                image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
+                image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
                 caches:
                   - npm
                   - node

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -24,7 +24,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.15.0
+          - image: cimg/node:24.18.0
         working_directory: ~/repo
 
     jobs:
@@ -58,11 +58,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-noble-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.60.0-noble
+          - image: mcr.microsoft.com/playwright:v1.61.1-noble
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.15.0
+          - image: cimg/node:24.18.0
         working_directory: ~/repo
 
     jobs:
@@ -130,11 +130,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       cypress:
         docker:
-          - image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
+          - image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.15.0
+          - image: cimg/node:24.18.0
         working_directory: ~/repo
 
     jobs:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -41,7 +41,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.60.0-noble
+        container: mcr.microsoft.com/playwright:v1.61.1-noble
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.
@@ -67,7 +67,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Cypress"
         displayName: "Run Cypress tests"
-        container: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
+        container: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
         environment:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         options:

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -29,12 +29,12 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v6
+            uses: actions/checkout@v7
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.15.0
+              node-version: 24.18.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -55,14 +55,14 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.60.0-noble
+          image: mcr.microsoft.com/playwright:v1.61.1-noble
         steps:
-          - uses: actions/checkout@v6
+          - uses: actions/checkout@v7
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.15.0
+              node-version: 24.18.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -83,12 +83,12 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         needs: playwright
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v6
+          - uses: actions/checkout@v7
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.15.0
+              node-version: 24.18.0
           - name: Install dependencies
              # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -119,15 +119,15 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         name: Run Cypress
         runs-on: ubuntu-latest
         container:
-          image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
+          image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
           options: --user 1001
         steps:
-          - uses: actions/checkout@v6
+          - uses: actions/checkout@v7
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.15.0
+              node-version: 24.18.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -150,12 +150,12 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v6
+            uses: actions/checkout@v7
             with:
               fetch-depth: 0
           - uses: actions/setup-node@v6
             with:
-              node-version: 24.15.0
+              node-version: 24.18.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -507,7 +507,7 @@ This means the latest build on main will be an ancestor of this ephemeral branch
 If you decide to use the `pull_request` event, we recommend creating a separate workflow for Chromatic using the following strategy for the checkout step:
 
 ```yml
-- uses: actions/checkout@v6
+- uses: actions/checkout@v7
   with:
     fetch-depth: 0
     # 👇 Tells the checkout which commit hash to reference

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -58,7 +58,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
       script:
         - npx playwright test
       allow_failure: true
@@ -98,7 +98,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Cypress:
       stage: UI_Tests
       needs: []
-      image: cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1
+      image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
       variables:
         ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
       script:

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -50,7 +50,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.60.0-noble'
+               image 'mcr.microsoft.com/playwright:v1.61.1-noble'
                reuseNode true
              }
            }
@@ -93,7 +93,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Cypress') {
            agent {
              docker {
-               image 'cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1'
+               image 'cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1'
                reuseNode true
              }
            }

--- a/src/content/ci/semaphore.mdx
+++ b/src/content/ci/semaphore.mdx
@@ -31,7 +31,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     global_job_config:
       prologue:
         commands:
-          - sem-version node 24.15.0
+          - sem-version node 24.18.0
           - checkout
 
     blocks:
@@ -74,7 +74,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               os_image: ubuntu2404
             containers:
               - name: Plawyright
-                image: mcr.microsoft.com/playwright:v1.60.0-noble
+                image: mcr.microsoft.com/playwright:v1.61.1-noble
           jobs:
             - name: Run Playwright
               commands:
@@ -122,7 +122,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     global_job_config:
       prologue:
         commands:
-          - sem-version node 24.15.0
+          - sem-version node 24.18.0
           - checkout
 
     blocks:

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -26,14 +26,14 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version: 24.18.0
       - name: Install dependencies
         run: npm ci
       - name: Run Playwright tests
@@ -52,12 +52,12 @@ jobs:
     needs: playwright
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version: 24.18.0
       - name: Install dependencies
         run: npm ci
 
@@ -96,7 +96,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.60.0-noble
+  image: mcr.microsoft.com/playwright:v1.61.1-noble
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -122,10 +122,10 @@ version: 2.1
 executors:
   pw-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.60.0-noble
+      - image: mcr.microsoft.com/playwright:v1.61.1-noble
   chromatic-ui-testing:
     docker:
-      - image: cimg/node:24.15.0
+      - image: cimg/node:24.18.0
 
 jobs:
   Playwright:
@@ -200,7 +200,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.60.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
               reuseNode true
             }
           }
@@ -220,7 +220,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.60.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
               reuseNode true
             }
           }
@@ -278,7 +278,7 @@ blocks:
           os_image: ubuntu2404
         containers:
           - name: Plawyright
-            image: mcr.microsoft.com/playwright:v1.60.0-noble
+            image: mcr.microsoft.com/playwright:v1.61.1-noble
       jobs:
         - name: Run Playwright
           commands:
@@ -317,7 +317,7 @@ image: node:krypton
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.60.0-noble
+    container: mcr.microsoft.com/playwright:v1.61.1-noble
     options:
       parallel: 2
       artifacts:

--- a/src/content/vitest/sharding.md
+++ b/src/content/vitest/sharding.md
@@ -28,14 +28,14 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version: 24.18.0
       - name: Install dependencies
         run: npm ci
       - name: Run Vitest tests
@@ -55,12 +55,12 @@ jobs:
     needs: vitest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.15.0
+          node-version: 24.18.0
       - name: Install dependencies
         run: npm ci
 
@@ -99,7 +99,7 @@ before_script:
 Vitest:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.60.0-noble
+  image: mcr.microsoft.com/playwright:v1.61.1-noble
   parallel: 2
   script:
     - npx vitest run --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -126,10 +126,10 @@ version: 2.1
 executors:
   vitest-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.60.0-noble
+      - image: mcr.microsoft.com/playwright:v1.61.1-noble
   chromatic-ui-testing:
     docker:
-      - image: cimg/node:24.15.0
+      - image: cimg/node:24.18.0
 
 jobs:
   Vitest:
@@ -204,7 +204,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.60.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
               reuseNode true
             }
           }
@@ -224,7 +224,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.60.0-noble'
+              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
               reuseNode true
             }
           }
@@ -282,7 +282,7 @@ blocks:
           os_image: ubuntu2404
         containers:
           - name: Vitest
-            image: mcr.microsoft.com/playwright:v1.60.0-noble
+            image: mcr.microsoft.com/playwright:v1.61.1-noble
       jobs:
         - name: Run Vitest
           commands:
@@ -300,7 +300,7 @@ blocks:
     task:
       prologue:
         commands:
-          - sem-version node 24.15.0
+          - sem-version node 24.18.0
           - artifact pull workflow .vitest
       secrets:
         - name: CHROMATIC_PROJECT_TOKEN
@@ -322,7 +322,7 @@ image: node:krypton
 - run:
     name: "Vitest"
     displayName: "Run Vitest tests"
-    container: mcr.microsoft.com/playwright:v1.60.0-noble
+    container: mcr.microsoft.com/playwright:v1.61.1-noble
     options:
       parallel: 2
       artifacts:


### PR DESCRIPTION
## Summary

Upgrades pinned versions in CI code examples under `src/content/ci/`, `src/content/playwright/`, and `src/content/vitest/` to their current latest stable/LTS releases:

- Node.js: `24.15.0` → `24.18.0` (LTS "Krypton", codename unchanged) — `node-version`, `cimg/node`, Azure `UseNode` task, Semaphore `sem-version`
- Playwright Docker image: `mcr.microsoft.com/playwright:v1.60.0-noble` → `v1.61.1-noble`
- Cypress Docker image: `cypress/browsers:node-24.15.0-chrome-148.0.7778.96-1-ff-150.0.3-edge-148.0.3967.54-1` → `node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1`
- `actions/checkout@v6` → `actions/checkout@v7`

`actions/setup-node@v6`, `actions/upload-artifact@v7`, and `actions/download-artifact@v8` are already pinned to their latest major version, so no change was needed there. Per the skill's scope, `src/content/ci/jenkins.md`'s node version (configured in the Jenkins app, not the CI examples) and `src/content/ci/travis.md` (outdated/unsupported) were left untouched.

## How to QA

- [ ] Skim the diff in each changed file to confirm only version strings changed, syntax/formatting is intact
- [ ] Spot-check a couple of rendered pages (e.g. `/docs/ci`, `/docs/playwright/sharding`, `/docs/vitest/sharding`) locally with `pnpm dev` to confirm code blocks still render correctly