### PR TITLE
docs: point playground tool links at chromatic.support domains

### DIFF
--- a/src/content/configuration/configure.mdx
+++ b/src/content/configuration/configure.mdx
@@ -16,7 +16,7 @@ Note that the config file only supports a subset of these options. Some options 
   **Glob Types**: Where supported, globs are handled via
   [picomatch](https://www.npmjs.com/package/picomatch#globbing-features). To learn more about globs
   and how to use them, refer to our [guide on globs](/docs/globs). To verify your glob pattern, use
-  the [picomatch-playground](https://picomatch-playground-ebjlxm.csb.app/).
+  the [picomatch-playground](https://globs.chromatic.support/).
 </div>
 
 ## Options

--- a/src/content/configuration/configure.mdx
+++ b/src/content/configuration/configure.mdx
@@ -16,7 +16,7 @@ Note that the config file only supports a subset of these options. Some options 
   **Glob Types**: Where supported, globs are handled via
   [picomatch](https://www.npmjs.com/package/picomatch#globbing-features). To learn more about globs
   and how to use them, refer to our [guide on globs](/docs/globs). To verify your glob pattern, use
-  the [picomatch-playground](https://globs.chromatic.support/).
+  the [picomatch-playground](https://tools.chromatic.support/globs/).
 </div>
 
 ## Options

--- a/src/content/guides/globs.md
+++ b/src/content/guides/globs.md
@@ -12,9 +12,9 @@ Chromatic handles globs using [picomatch](https://www.npmjs.com/package/picomatc
 
 ## How to verify your glob pattern
 
-[Picomatch playground](https://picomatch-playground-ebjlxm.csb.app/) is a handy tool for testing your glob patterns. Let's look at some examples to understand how to use globs with Chromatic.
+[Picomatch playground](https://globs.chromatic.support/) is a handy tool for testing your glob patterns. Let's look at some examples to understand how to use globs with Chromatic.
 
-Imagine we have a project with the following list of files. Copy and paste it into the `File structure` text box of the [Picomatch playground](https://picomatch-playground-ebjlxm.csb.app/).
+Imagine we have a project with the following list of files. Copy and paste it into the `File structure` text box of the [Picomatch playground](https://globs.chromatic.support/).
 
 ```
 .stories/preview.jsx

--- a/src/content/guides/globs.md
+++ b/src/content/guides/globs.md
@@ -12,9 +12,9 @@ Chromatic handles globs using [picomatch](https://www.npmjs.com/package/picomatc
 
 ## How to verify your glob pattern
 
-[Picomatch playground](https://globs.chromatic.support/) is a handy tool for testing your glob patterns. Let's look at some examples to understand how to use globs with Chromatic.
+[Picomatch playground](https://tools.chromatic.support/globs/) is a handy tool for testing your glob patterns. Let's look at some examples to understand how to use globs with Chromatic.
 
-Imagine we have a project with the following list of files. Copy and paste it into the `File structure` text box of the [Picomatch playground](https://globs.chromatic.support/).
+Imagine we have a project with the following list of files. Copy and paste it into the `File structure` text box of the [Picomatch playground](https://tools.chromatic.support/globs/).
 
 ```
 .stories/preview.jsx

--- a/src/content/snapshot/threshold.mdx
+++ b/src/content/snapshot/threshold.mdx
@@ -88,7 +88,7 @@ If you need to customize how Chromatic identifies visual changes in your UI, add
 
 Choose the lowest threshold that filters out expected visual noise without hiding meaningful changes. For example, a threshold of `0.8` may prevent Chromatic from detecting positioning changes.
 
-Use the [**interactive diff tool**](https://6262c53f521620003ac2ff49-ukmsdlppcb.chromatic.com/?path=/story/stories-diff-threshold-check--test-yours-out) to preview how different values affect your UI tests.
+Use the [**interactive diff tool**](https://threshold.chromatic.support) to preview how different values affect your UI tests.
 
 ### Anti-aliasing
 
@@ -173,7 +173,7 @@ Chromatic uses a threshold to determine how much must change between snapshots b
 
 However, our default threshold may miss subtle changes, such as nuanced changes to a background's shade of gray. In this case, you may want to adjust the `diffThreshold` to be more accurate (lower value).
 
-Find the suitable threshold for your UI using our [**interactive diff tool**](https://6262c53f521620003ac2ff49-ukmsdlppcb.chromatic.com/?path=/story/stories-diff-threshold-check--test-yours-out).
+Find the suitable threshold for your UI using our [**interactive diff tool**](https://threshold.chromatic.support).
 
 </details>
 

--- a/src/content/snapshot/threshold.mdx
+++ b/src/content/snapshot/threshold.mdx
@@ -88,7 +88,7 @@ If you need to customize how Chromatic identifies visual changes in your UI, add
 
 Choose the lowest threshold that filters out expected visual noise without hiding meaningful changes. For example, a threshold of `0.8` may prevent Chromatic from detecting positioning changes.
 
-Use the [**interactive diff tool**](https://threshold.chromatic.support) to preview how different values affect your UI tests.
+Use the [**interactive diff tool**](https://tools.chromatic.support/threshold/) to preview how different values affect your UI tests.
 
 ### Anti-aliasing
 
@@ -173,7 +173,7 @@ Chromatic uses a threshold to determine how much must change between snapshots b
 
 However, our default threshold may miss subtle changes, such as nuanced changes to a background's shade of gray. In this case, you may want to adjust the `diffThreshold` to be more accurate (lower value).
 
-Find the suitable threshold for your UI using our [**interactive diff tool**](https://threshold.chromatic.support).
+Find the suitable threshold for your UI using our [**interactive diff tool**](https://tools.chromatic.support/threshold/).
 
 </details>
 

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -298,7 +298,7 @@ chromatic --only-changed --externals "*.sass" --externals "public/**"
 
 <div class="aside">
 
-Globs not working as you expected? Verify your pattern using this [picomatch-playground](https://picomatch-playground-ebjlxm.csb.app/).
+Globs not working as you expected? Verify your pattern using this [picomatch-playground](https://globs.chromatic.support/).
 
 </div>
 

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -298,7 +298,7 @@ chromatic --only-changed --externals "*.sass" --externals "public/**"
 
 <div class="aside">
 
-Globs not working as you expected? Verify your pattern using this [picomatch-playground](https://globs.chromatic.support/).
+Globs not working as you expected? Verify your pattern using this [picomatch-playground](https://tools.chromatic.support/globs/).
 
 </div>
 


### PR DESCRIPTION
## TL;DR

Replaces hardcoded third-party URLs for the Picomatch Playground and Threshold Playground tools with their new stable homes under `tools.chromatic.support` (part of [TOO-179](https://linear.app/chromaui/issue/TOO-179): the tools moved into chromaui/customer-tools#1).

## Changes

- `https://picomatch-playground-ebjlxm.csb.app/` → `https://tools.chromatic.support/globs/` in:
  - `src/content/configuration/configure.mdx`
  - `src/content/guides/globs.md` (2 occurrences)
  - `src/content/turbosnap/setup-turbosnap.mdx`
- `https://6262c53f521620003ac2ff49-ukmsdlppcb.chromatic.com/?path=...` (interactive diff tool) → `https://tools.chromatic.support/threshold/` in:
  - `src/content/snapshot/threshold.mdx` (2 occurrences)

## Merge order

The new domain is now live — merge after chromaui/cloud-infrastructure#355 (DNS) lands and Pages is configured on chromaui/customer-tools. Re-verify the URLs return 200 at that point.

Parallel PRs: chromaui/customer-tools#1 (monorepo) · chromaui/cloud-infrastructure#355 (DNS) · chromaui/picomatch-glob-tool#5 and chromaui/diff-threshold-check#1 (redirect stubs for the old subdomains).

## Verification

- Grepped `src/` for the old URLs and the interim `globs.`/`threshold.chromatic.support` subdomains — no occurrences remain; all six links point at `tools.chromatic.support` paths.
- Link text and surrounding prose unchanged; content-only diff, no internal links affected.
- Live-URL check pending the DNS/Pages rollout above.

