### PR TITLE
chore: upgrade @chromatic-com/tetra to v3.2.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@astrojs/mdx": "^5.0.1",
     "@astrojs/react": "^5.0.0",
     "@astrojs/sitemap": "^3.7.1",
-    "@chromatic-com/tetra": "3.2.17",
+    "@chromatic-com/tetra": "3.2.19",
     "@docsearch/css": "^3.5.2",
     "@emotion/react": "^11.13.3",
     "@emotion/server": "^11.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.7.1
         version: 3.7.1
       '@chromatic-com/tetra':
-        specifier: 3.2.17
-        version: 3.2.17(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@types/react@18.2.21)(react@18.2.0))(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@11.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 3.2.19
+        version: 3.2.19(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@types/react@18.2.21)(react@18.2.0))(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@11.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docsearch/css':
         specifier: ^3.5.2
         version: 3.5.2
@@ -378,8 +378,8 @@ packages:
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
 
-  '@chromatic-com/tetra@3.2.17':
-    resolution: {integrity: sha512-dew9ep9rRz51OUSM1OucLtB+WKMeYjYliaEoHOrSPLEgVJuVmXmJrSzsdj+vVGa7P/UqJP05JDRe13ngapUP8Q==}
+  '@chromatic-com/tetra@3.2.19':
+    resolution: {integrity: sha512-597vDI97+v8f88Xg48m7s1UbptES/TH3mjxbU2iChcD4Pk9GasqND0CKJotIO+qZ/4D7KGOWD1qpfZ3LAc+rNg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.13.3
@@ -5560,7 +5560,7 @@ snapshots:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
 
-  '@chromatic-com/tetra@3.2.17(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@types/react@18.2.21)(react@18.2.0))(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@11.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@chromatic-com/tetra@3.2.19(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@types/react@18.2.21)(react@18.2.0))(@types/react-dom@18.2.7)(@types/react@18.2.21)(framer-motion@11.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.2.21)(react@18.2.0)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.2.21)(react@18.2.0))(@types/react@18.2.21)(react@18.2.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ allowBuilds:
   esbuild: true
   lefthook: true
   sharp: true
+minimumReleaseAgeExclude:
+  - '@chromatic-com/tetra@3.2.19'


### PR DESCRIPTION
## Summary

Upgrades `@chromatic-com/tetra` from **3.2.17 → 3.2.19** (exact pin, no caret, in `dependencies`).

This is a version-bump-only upgrade. The changes between these tetra versions are purely additive Header/Footer navigation data — no breaking API changes.

## What changed in tetra (3.2.17 → 3.2.19)

A new **"Live sessions"** link (`/live-sessions`) was added to the shared Header and Footer:

- `src/Header/data.tsx` — new `liveSessions` entry in `defaultLinks` (`icon: 'video'`, `iconColor: 'orange500'`) and a new desktop-menu item with description "Deep dives into frontend testing, Storybook, and shipping better UI".
- `src/Header/types.ts` — `LinkKeys` union gained `'liveSessions'`.
- `src/Footer/data.tsx` — `createFooterColumns` gained a `{ title: 'Live sessions', href: '/live-sessions' }` entry.

## What was updated in this repo

- `package.json` — `@chromatic-com/tetra` bumped to exact `3.2.19`.
- `pnpm-lock.yaml` — regenerated.
- `pnpm-workspace.yaml` — pnpm auto-added a `minimumReleaseAgeExclude` entry for `@chromatic-com/tetra@3.2.19`. This is **required**: the repo pins `pnpm@11.2.2`, which enforces a minimum-release-age policy, and 3.2.19 was published today. Without the exclude, `pnpm install` (run unfrozen in CI) would refuse to install the fresh release.

**No wrapper component changes were needed.** I verified this against tetra's source:

- **Header** (`src/components/Header/MarketingHeader.tsx` + `headerData.tsx`): tetra's `Header` builds its link set by iterating `defaultLinks` and layering the passed `links` overrides on top (`{ ...defaultValue, ...override }`). Because `liveSessions` now lives in `defaultLinks`, the merged links object — and therefore `createDesktopMenu` — picks it up automatically even though this repo's custom `headerData.tsx` doesn't declare it. The "Live sessions" menu item appears without any local edit.
- **Footer** (`src/components/Footer/MarketingFooter.tsx`): tetra's `Footer` builds its columns internally via `createFooterColumns(LinkWrapper)`; the repo passes no custom columns, so the new "Live sessions" footer link is inherited automatically.

## Verification

- `pnpm test:unit` — **passed** (5 test files, 45 tests).
- `pnpm build` (`astro build`) — **fails locally**, but this is **pre-existing and unrelated to this upgrade**. The failure is `Invalid URL` from `fetch(import.meta.env.HYGRAPH_ENDPOINT, …)` in `src/pages/[cms_slug].astro`'s `getStaticPaths`, because the `HYGRAPH_ENDPOINT` secret is not set in the local sandbox. I confirmed a pristine `origin/main` checkout (tetra 3.2.17, no changes) fails the build with the **identical** error and exit code. In CI, where `HYGRAPH_ENDPOINT` is available, the build succeeds.

## Visual review

This repo's Chromatic CI build will attach visual diffs for the Header/Footer, which should show the new "Live sessions" navigation and footer links.
