### PR TITLE
docs(billing): split usage reports into its own page

### DIFF
--- a/src/content/account/acceptable-use.md
+++ b/src/content/account/acceptable-use.md
@@ -1,7 +1,7 @@
 ---
 title: Acceptable Use Policy
 description: Chromatic Acceptable Use Policy
-sidebar: { order: 8 }
+sidebar: { order: 10 }
 ---
 
 # Acceptable Use Policy

--- a/src/content/account/billing.mdx
+++ b/src/content/account/billing.mdx
@@ -4,7 +4,7 @@ description: Chromatic billing information
 sidebar: { order: 2, label: Billing & invoices }
 ---
 
-# Billing and invoices
+# Billing
 
 Chromatic bills customers monthly based on their subscription date. For example, if you subscribed on February 14, you'll be billed on the 14th of each month.
 
@@ -66,7 +66,7 @@ billed snapshots = visual snapshots + accessibility snapshots + billed snapshots
 
 ### Billed snapshots are counted at the account level
 
-If your account has multiple projects, we sum the billed snapshots each project incurs to get your total usage. You can see a breakdown of billed snapshots by project in the [usage report](#usage-reports) for each billing period.
+If your account has multiple projects, we sum the billed snapshots each project incurs to get your total usage. You can see a breakdown of billed snapshots by project in the [usage report](/docs/billing/usage-reports) for each billing period.
 
 A couple more things to note:
 
@@ -102,96 +102,6 @@ For example, if you want to get a notification when you use 90% of the 35,000 bi
 ### Data retention
 
 Chromatic guarantees a minimum of 12 months of data retention for builds and snapshots on all plans.
-
-## Usage reports
-
-Access usage reports for each billing period on the billing page. These reports offer a detailed breakdown of usage and display the invoice statement.
-
-The **usage section** provides a per-project summary of Visual, Accessibility and TurboSnap snapshots utilized.
-
-The **invoice** includes details of the active plan for the billing period, the base number of billed snapshots included, charges for additional billed snapshots, and a link to download a PDF copy of the invoice (available for all billing periods).
-
-![Example of a usage report that shows a breakdown of billed snapshots by project and the invoice details](../../images/usage-report.png)
-
-To access the current billing period's usage report, click on the "View usage" button in the Plan section.
-
-![Access current billing period's usage report from the Plan section](../../images/usage-report-current-period.png)
-
-To view previous billing periods, click on the card for the desired period in the Statements section.
-
-![Access a previous billing period's usage report from the statements section](../../images/usage-report-past-periods.png)
-
-### Export usage data as a CSV
-
-You can generate a CSV file with a detailed list of every build within a build period. Click on a billing period to view the Usage Report, then click the "Download CSV" button to get a CSV file for that period.
-
-The CSV file provides a granular breakdown of usage and includes the following columns:
-
-<dl>
-  <dt>Date</dt>
-  <dd>Creation date and time of the build (ISO 8601)</dd>
-
-<dt>App ID</dt>
-<dd>Unique Chromatic project identifier</dd>
-
-<dt>Build ID</dt>
-<dd>Unique Chromatic build identifier</dd>
-
-  <dt>Repository slug</dt>
-  <dd>
-    Owner and name of the Git repository linked to the project (`<ownerName>:<repoName>`)
-  </dd>
-
-  <dt>Branch name</dt>
-  <dd>
-    Git branch name for which the build was created, prefixed with `<ownerName>:` if the build originates from a fork
-  </dd>
-
-<dt>Build number</dt>
-<dd>The incremental number for this build</dd>
-
-  <dt>turbosnaps</dt>
-  <dd>
-
-Number of snapshots copied by [TurboSnap](#with-turbosnap-enabled).
-
-  </dd>
-
-  <dt>TurboSnap Bail Reason</dt>
-  <dd>
-
-Explains why a TurboSnap triggered a full rebuild. For more details, check out the [TurboSnap docs](/docs/turbosnap/troubleshooting#what-do-the-turbosnap-bail-reasons-in-my-usage-report-mean).
-
-  </dd>
-
-<dt>Chrome snapshots</dt>
-<dd>Number of captured visual Chrome snapshots</dd>
-
-<dt>Firefox snapshots</dt>
-<dd>Number of captured visual Firefox snapshots</dd>
-
-<dt>Safari snapshots</dt>
-<dd>Number of captured visual Safari snapshots</dd>
-
-<dt>Edge snapshots</dt>
-<dd>Number of captured visual Edge snapshots</dd>
-
-{' '}
-
-<dt>Internet Explorer snapshots</dt>
-<dd>Phased out in 2023. Number of captured visual Internet Explorer snapshots.</dd>
-
-  <dt>Accessibility snapshots</dt>
-  <dd>Number of captured accessibility snapshots</dd>
-</dl>
-
-### Export monthly and yearly usage data as CSV
-
-Usage reports export your account's activity for the chosen billing period. You can also download a CSV of your monthly or yearly snapshot usage across all your projects' builds. Click the "Generate report" button and select a year and/or month, and then click "Generate CSV."
-
-For a custom date range or to get the report in JSON format, contact us via in-app chat or [email](mailto:support@chromatic.com).
-
-![Setup usage report](../../images/billing-usage-report.png)
 
 ## Change plans
 

--- a/src/content/account/infrastructure-upgrades.md
+++ b/src/content/account/infrastructure-upgrades.md
@@ -1,7 +1,7 @@
 ---
 title: Infrastructure upgrades
 description: Learn how Chromatic handles browser rendering changes to be minimally disruptive
-sidebar: { order: 4 }
+sidebar: { order: 6 }
 ---
 
 # Infrastructure upgrades

--- a/src/content/account/notifications.md
+++ b/src/content/account/notifications.md
@@ -1,7 +1,7 @@
 ---
 title: Notifications
 description: Control when and how you receive activity notifications
-sidebar: { order: 3 }
+sidebar: { order: 5 }
 ---
 
 # Notifications

--- a/src/content/account/open-source.mdx
+++ b/src/content/account/open-source.mdx
@@ -1,7 +1,7 @@
 ---
 title: Open source sponsorships
 description: Chromatic sponsors open source component libraries
-sidebar: { order: 9, label: Open source plan }
+sidebar: { order: 11, label: Open source plan }
 ---
 
 import { PlainOpenLink } from '../../components/PlainOpenLink';

--- a/src/content/account/privacy-policy.md
+++ b/src/content/account/privacy-policy.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy Policy
 description: Chromatic Privacy Policy
-sidebar: { order: 7 }
+sidebar: { order: 9 }
 ---
 
 # Privacy and Cookies Notice

--- a/src/content/account/security.md
+++ b/src/content/account/security.md
@@ -1,7 +1,7 @@
 ---
 title: Security
 description: Security overview and responsible disclosure
-sidebar: { order: 5 }
+sidebar: { order: 7 }
 ---
 
 # Security policy

--- a/src/content/account/terms-of-service.md
+++ b/src/content/account/terms-of-service.md
@@ -1,7 +1,7 @@
 ---
 title: Terms of Service
 description: Chromatic Terms of Service
-sidebar: { order: 6 }
+sidebar: { order: 8 }
 ---
 
 # Terms of Service

--- a/src/content/account/usage-reports.mdx
+++ b/src/content/account/usage-reports.mdx
@@ -1,0 +1,96 @@
+---
+title: Usage reports & exports
+description: View and export detailed billing period usage reports, including a CSV breakdown of every build
+sidebar: { order: 4, label: Usage reports }
+slug: 'billing/usage-reports'
+---
+
+# Usage reports & exports
+
+Access usage reports for each billing period on the billing page. These reports offer a detailed breakdown of usage and display the invoice statement.
+
+The **usage section** provides a per-project summary of Visual, Accessibility and TurboSnap snapshots utilized.
+
+The **invoice** includes details of the active plan for the billing period, the base number of billed snapshots included, charges for additional billed snapshots, and a link to download a PDF copy of the invoice (available for all billing periods).
+
+![Example of a usage report that shows a breakdown of billed snapshots by project and the invoice details](../../images/usage-report.png)
+
+To access the current billing period's usage report, click on the "View usage" button in the Plan section.
+
+![Access current billing period's usage report from the Plan section](../../images/usage-report-current-period.png)
+
+To view previous billing periods, click on the card for the desired period in the Statements section.
+
+![Access a previous billing period's usage report from the statements section](../../images/usage-report-past-periods.png)
+
+## Export usage data as a CSV
+
+You can generate a CSV file with a detailed list of every build within a build period. Click on a billing period to view the Usage Report, then click the "Download CSV" button to get a CSV file for that period.
+
+The CSV file provides a granular breakdown of usage and includes the following columns:
+
+<dl>
+  <dt>Date</dt>
+  <dd>Creation date and time of the build (ISO 8601)</dd>
+
+<dt>App ID</dt>
+<dd>Unique Chromatic project identifier</dd>
+
+<dt>Build ID</dt>
+<dd>Unique Chromatic build identifier</dd>
+
+  <dt>Repository slug</dt>
+  <dd>
+    Owner and name of the Git repository linked to the project (`<ownerName>:<repoName>`)
+  </dd>
+
+  <dt>Branch name</dt>
+  <dd>
+    Git branch name for which the build was created, prefixed with `<ownerName>:` if the build originates from a fork
+  </dd>
+
+<dt>Build number</dt>
+<dd>The incremental number for this build</dd>
+
+  <dt>turbosnaps</dt>
+  <dd>
+
+Number of snapshots copied by [TurboSnap](/docs/billing#with-turbosnap-enabled).
+
+  </dd>
+
+  <dt>TurboSnap Bail Reason</dt>
+  <dd>
+
+Explains why a TurboSnap triggered a full rebuild. For more details, check out the [TurboSnap docs](/docs/turbosnap/troubleshooting#what-do-the-turbosnap-bail-reasons-in-my-usage-report-mean).
+
+  </dd>
+
+<dt>Chrome snapshots</dt>
+<dd>Number of captured visual Chrome snapshots</dd>
+
+<dt>Firefox snapshots</dt>
+<dd>Number of captured visual Firefox snapshots</dd>
+
+<dt>Safari snapshots</dt>
+<dd>Number of captured visual Safari snapshots</dd>
+
+<dt>Edge snapshots</dt>
+<dd>Number of captured visual Edge snapshots</dd>
+
+{' '}
+
+<dt>Internet Explorer snapshots</dt>
+<dd>Phased out in 2023. Number of captured visual Internet Explorer snapshots.</dd>
+
+  <dt>Accessibility snapshots</dt>
+  <dd>Number of captured accessibility snapshots</dd>
+</dl>
+
+## Export monthly and yearly usage data as CSV
+
+Usage reports export your account's activity for the chosen billing period. You can also download a CSV of your monthly or yearly snapshot usage across all your projects' builds. Click the "Generate report" button and select a year and/or month, and then click "Generate CSV."
+
+For a custom date range or to get the report in JSON format, contact us via in-app chat or [email](mailto:support@chromatic.com).
+
+![Setup usage report](../../images/billing-usage-report.png)

--- a/src/content/turbosnap/troubleshooting-turbosnap.mdx
+++ b/src/content/turbosnap/troubleshooting-turbosnap.mdx
@@ -70,7 +70,7 @@ TurboSnap is compatible with squash and merge rebasing as of version 6.6+. Pleas
 
 ## What do the TurboSnap bail reasons in my usage report mean?
 
-Your [usage data (CSV report)](/docs/billing#export-usage-data-as-a-csv) can help you faster identify opportunities to improve your TurboSnap configuration. The "TurboSnaps Bail Reason" column tells you what caused TurboSnap triggered a full rebuild. Here's what each reason means:
+Your [usage data (CSV report)](/docs/billing/usage-reports#export-usage-data-as-a-csv) can help you faster identify opportunities to improve your TurboSnap configuration. The "TurboSnaps Bail Reason" column tells you what caused TurboSnap triggered a full rebuild. Here's what each reason means:
 
 ### `changedExternalFiles`
 


### PR DESCRIPTION
Extract the "Usage reports" section out of billing.mdx into a new account/usage-reports.mdx page at /docs/billing/usage-reports, trim Billing's H1 to "Billing", and repoint the two cross-links that referenced the moved content. Bump sidebar order on other Account pages to make room, reserving order 3 for the upcoming Usage trends page.

Part of CHDX-1119.