### PR TITLE
Docs: Upgrade CI images node versions and action versions across the documentation

### DIFF
--- a/src/content/ci/azure-pipelines.mdx
+++ b/src/content/ci/azure-pipelines.mdx
@@ -38,7 +38,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.18.0"
+                  version: "24.19.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -70,7 +70,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Playwright
             displayName: "Run Playwright"
-            container: mcr.microsoft.com/playwright:v1.61.1-noble
+            container: mcr.microsoft.com/playwright:v1.62.0-noble
             steps:
               - checkout: self
                 displayName: "Get Full Git History"
@@ -78,7 +78,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.18.0"
+                  version: "24.19.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -114,7 +114,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.18.0"
+                  version: "24.19.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -152,7 +152,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
         jobs:
           - job: Cypress
             displayName: "Run Cypress"
-            container: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
+            container: cypress/browsers:node-24.19.0-chrome-151.0.7922.75-1-ff-153.0.3-edge-151.0.4129.59-1
             variables:
               npm_config_cache: $(Pipeline.Workspace)/.npm
             steps:
@@ -162,7 +162,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.18.0"
+                  version: "24.19.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:
@@ -200,7 +200,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - task: UseNode@1
                 displayName: "Install Node.js"
                 inputs:
-                  version: "24.18.0"
+                  version: "24.19.0"
               - task: Cache@2
                 displayName: "Install and cache dependencies"
                 inputs:

--- a/src/content/ci/bitbucket-pipelines.mdx
+++ b/src/content/ci/bitbucket-pipelines.mdx
@@ -56,7 +56,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
             steps:
               - step:
                   name: "Playwright"
-                  image: mcr.microsoft.com/playwright:v1.61.1-noble
+                  image: mcr.microsoft.com/playwright:v1.62.0-noble
                   caches:
                     - npm
                     - node
@@ -95,7 +95,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
               - step:
                 name: "Cypress"
                 # Configure the ELECTRON_EXTRA_LAUNCH_ARGS environment variable in your project settings to run Cypress tests with Chromatic.
-                image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
+                image: cypress/browsers:node-24.19.0-chrome-151.0.7922.75-1-ff-153.0.3-edge-151.0.4129.59-1
                 caches:
                   - npm
                   - node

--- a/src/content/ci/circleci.mdx
+++ b/src/content/ci/circleci.mdx
@@ -24,7 +24,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.18.0
+          - image: cimg/node:24.19.0
         working_directory: ~/repo
 
     jobs:
@@ -58,11 +58,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       pw-noble-development:
         docker:
-          - image: mcr.microsoft.com/playwright:v1.61.1-noble
+          - image: mcr.microsoft.com/playwright:v1.62.0-noble
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.18.0
+          - image: cimg/node:24.19.0
         working_directory: ~/repo
 
     jobs:
@@ -130,11 +130,11 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     executors:
       cypress:
         docker:
-          - image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
+          - image: cypress/browsers:node-24.19.0-chrome-151.0.7922.75-1-ff-153.0.3-edge-151.0.4129.59-1
         working_directory: ~/repo
       chromatic-ui-testing:
         docker:
-          - image: cimg/node:24.18.0
+          - image: cimg/node:24.19.0
         working_directory: ~/repo
 
     jobs:

--- a/src/content/ci/custom-ci-provider.mdx
+++ b/src/content/ci/custom-ci-provider.mdx
@@ -41,7 +41,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Playwright"
         displayName: "Run Playwright tests"
-        container: mcr.microsoft.com/playwright:v1.61.1-noble
+        container: mcr.microsoft.com/playwright:v1.62.0-noble
         options:
           artifacts:
             # Chromatic automatically defaults to the test-results directory.
@@ -67,7 +67,7 @@ To integrate Chromatic with your existing CI provider, you'll need to add the fo
     - run:
         name: "Cypress"
         displayName: "Run Cypress tests"
-        container: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
+        container: cypress/browsers:node-24.19.0-chrome-151.0.7922.75-1-ff-153.0.3-edge-151.0.4129.59-1
         environment:
           ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
         options:

--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -32,9 +32,9 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
             uses: actions/checkout@v7
             with:
               fetch-depth: 0
-          - uses: actions/setup-node@v6
+          - uses: actions/setup-node@v7
             with:
-              node-version: 24.18.0
+              node-version: 24.19.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -55,14 +55,14 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
       playwright:
         runs-on: ubuntu-latest
         container:
-          image: mcr.microsoft.com/playwright:v1.61.1-noble
+          image: mcr.microsoft.com/playwright:v1.62.0-noble
         steps:
           - uses: actions/checkout@v7
             with:
               fetch-depth: 0
-          - uses: actions/setup-node@v6
+          - uses: actions/setup-node@v7
             with:
-              node-version: 24.18.0
+              node-version: 24.19.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -86,9 +86,9 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
           - uses: actions/checkout@v7
             with:
               fetch-depth: 0
-          - uses: actions/setup-node@v6
+          - uses: actions/setup-node@v7
             with:
-              node-version: 24.18.0
+              node-version: 24.19.0
           - name: Install dependencies
              # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -119,15 +119,15 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
         name: Run Cypress
         runs-on: ubuntu-latest
         container:
-          image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
+          image: cypress/browsers:node-24.19.0-chrome-151.0.7922.75-1-ff-153.0.3-edge-151.0.4129.59-1
           options: --user 1001
         steps:
           - uses: actions/checkout@v7
             with:
               fetch-depth: 0
-          - uses: actions/setup-node@v6
+          - uses: actions/setup-node@v7
             with:
-              node-version: 24.18.0
+              node-version: 24.19.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci
@@ -153,9 +153,9 @@ In your `.github/workflows` directory, create a new file called `chromatic.yml` 
             uses: actions/checkout@v7
             with:
               fetch-depth: 0
-          - uses: actions/setup-node@v6
+          - uses: actions/setup-node@v7
             with:
-              node-version: 24.18.0
+              node-version: 24.19.0
           - name: Install dependencies
             # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
             run: npm ci

--- a/src/content/ci/gitlab.mdx
+++ b/src/content/ci/gitlab.mdx
@@ -58,7 +58,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Playwright:
       stage: UI_Tests
       needs: []
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.0-noble
       script:
         - npx playwright test
       allow_failure: true
@@ -98,7 +98,7 @@ To integrate Chromatic with your existing pipeline, you'll need to add the follo
     Cypress:
       stage: UI_Tests
       needs: []
-      image: cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1
+      image: cypress/browsers:node-24.19.0-chrome-151.0.7922.75-1-ff-153.0.3-edge-151.0.4129.59-1
       variables:
         ELECTRON_EXTRA_LAUNCH_ARGS: "--remote-debugging-port=9222"
       script:

--- a/src/content/ci/jenkins.mdx
+++ b/src/content/ci/jenkins.mdx
@@ -50,7 +50,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Playwright') {
            agent {
              docker {
-               image 'mcr.microsoft.com/playwright:v1.61.1-noble'
+               image 'mcr.microsoft.com/playwright:v1.62.0-noble'
                reuseNode true
              }
            }
@@ -93,7 +93,7 @@ To integrate Chromatic with your existing [multistage pipeline](https://www.jenk
          stage('Cypress') {
            agent {
              docker {
-               image 'cypress/browsers:node-24.18.0-chrome-150.0.7871.46-1-ff-152.0.5-edge-150.0.4078.48-1'
+               image 'cypress/browsers:node-24.19.0-chrome-151.0.7922.75-1-ff-153.0.3-edge-151.0.4129.59-1'
                reuseNode true
              }
            }

--- a/src/content/ci/semaphore.mdx
+++ b/src/content/ci/semaphore.mdx
@@ -31,7 +31,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     global_job_config:
       prologue:
         commands:
-          - sem-version node 24.18.0
+          - sem-version node 24.19.0
           - checkout
 
     blocks:
@@ -74,7 +74,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
               os_image: ubuntu2404
             containers:
               - name: Plawyright
-                image: mcr.microsoft.com/playwright:v1.61.1-noble
+                image: mcr.microsoft.com/playwright:v1.62.0-noble
           jobs:
             - name: Run Playwright
               commands:
@@ -94,6 +94,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
         task:
           prologue:
             commands:
+              - sem-version node 24.19.0
               - artifact pull workflow test-results
           secrets:
             - name: CHROMATIC_PROJECT_TOKEN
@@ -122,7 +123,7 @@ To integrate Chromatic with your existing workflow, you'll need to add the follo
     global_job_config:
       prologue:
         commands:
-          - sem-version node 24.18.0
+          - sem-version node 24.19.0
           - checkout
 
     blocks:

--- a/src/content/notInNavigation/react-native.mdx
+++ b/src/content/notInNavigation/react-native.mdx
@@ -226,41 +226,34 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.3.app
-
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
-
       - name: Install dependencies
-        run: npm install
-
+        run: npm ci
       - name: Cache CocoaPods spec repo
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cocoapods
           key: cocoapods-specs-${{ hashFiles('package.json', 'app.json') }}
           restore-keys: |
             cocoapods-specs-
-
       - name: Cache Pods directory
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ios/Pods
           key: ios-pods-${{ hashFiles('package.json', 'app.json') }}
           restore-keys: |
             ios-pods-
-
       - name: Build iOS
         run: npx --yes chromatic react-native-build --platform=ios --output-dir=build
-
       - name: Upload iOS build
         uses: actions/upload-artifact@v7
         with:
@@ -272,44 +265,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
-
       - name: Cache Gradle wrapper
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('package.json', 'app.json') }}
-
       - name: Cache Gradle dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.gradle/caches
           key: gradle-caches-${{ hashFiles('package.json', 'app.json') }}
           restore-keys: |
             gradle-caches-
-
       - name: Cache Android directory
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: android/
           key: android-dir-${{ hashFiles('package.json', 'app.json') }}
           restore-keys: |
             android-dir-
-
       - name: Install dependencies
-        run: npm install
-
+        run: npm ci
       - name: Build Android
         run: npx --yes chromatic react-native-build --platform=android --output-dir=build
-
       - name: Upload Android build
         uses: actions/upload-artifact@v7
         with:
@@ -322,37 +308,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
           cache: npm
-
       - name: Install dependencies
-        run: npm install
-
+        run: npm ci
       - name: Download iOS build
         uses: actions/download-artifact@v8
         with:
           name: ios-build
           path: build/ios
-
       - name: Download Android build
         uses: actions/download-artifact@v8
         with:
           name: android-build
           path: build/android
-
       - name: Move Storybook static files
         run: |
           mkdir -p storybook-static
           mv build/ios/storybook.app storybook-static/
           mv build/android/storybook.apk storybook-static/
-
       - name: Publish to Chromatic
         run: npx --yes chromatic -d storybook-static --exit-zero-on-changes --exit-zero-on-errors
         env:
@@ -407,7 +387,6 @@ jobs:
     params:
       platform: ios
       profile: storybook
-
   build_android:
     name: Build Android Storybook
     type: build
@@ -465,19 +444,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24.19.0
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Download EAS build artifacts
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -487,7 +463,6 @@ jobs:
           cp -R "$IOS_PATH" storybook-static/storybook.app
           ANDROID_PATH=$(npx eas-cli build:download --build-id "${{ inputs.android_build_id }}" --non-interactive --json | jq -r '.path')
           cp "$ANDROID_PATH" storybook-static/storybook.apk
-
       - name: Run Chromatic
         uses: chromaui/action@latest
         with:
@@ -556,5 +531,3 @@ Not yet via the [modes API](/docs/modes). You can write a separate story per var
 Not yet
 
 </details>
-
----

--- a/src/content/playwright/sharding.md
+++ b/src/content/playwright/sharding.md
@@ -26,14 +26,14 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.0-noble
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
-          node-version: 24.18.0
+          node-version: 24.19.0
       - name: Install dependencies
         run: npm ci
       - name: Run Playwright tests
@@ -55,9 +55,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
-          node-version: 24.18.0
+          node-version: 24.19.0
       - name: Install dependencies
         run: npm ci
 
@@ -96,7 +96,7 @@ before_script:
 Playwright:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.61.1-noble
+  image: mcr.microsoft.com/playwright:v1.62.0-noble
   parallel: 2
   script:
     - npx playwright test --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -122,10 +122,10 @@ version: 2.1
 executors:
   pw-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.61.1-noble
+      - image: mcr.microsoft.com/playwright:v1.62.0-noble
   chromatic-ui-testing:
     docker:
-      - image: cimg/node:24.18.0
+      - image: cimg/node:24.19.0
 
 jobs:
   Playwright:
@@ -200,7 +200,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
+              image 'mcr.microsoft.com/playwright:v1.62.0-noble'
               reuseNode true
             }
           }
@@ -220,7 +220,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
+              image 'mcr.microsoft.com/playwright:v1.62.0-noble'
               reuseNode true
             }
           }
@@ -278,7 +278,7 @@ blocks:
           os_image: ubuntu2404
         containers:
           - name: Plawyright
-            image: mcr.microsoft.com/playwright:v1.61.1-noble
+            image: mcr.microsoft.com/playwright:v1.62.0-noble
       jobs:
         - name: Run Playwright
           commands:
@@ -296,6 +296,7 @@ blocks:
     task:
       prologue:
         commands:
+          - sem-version node 24.19.0
           - artifact pull workflow test-results
       secrets:
         - name: CHROMATIC_PROJECT_TOKEN
@@ -317,7 +318,7 @@ image: node:krypton
 - run:
     name: "Playwright"
     displayName: "Run Playwright tests"
-    container: mcr.microsoft.com/playwright:v1.61.1-noble
+    container: mcr.microsoft.com/playwright:v1.62.0-noble
     options:
       parallel: 2
       artifacts:

--- a/src/content/troubleshooting/faq/chromatic-draft-pr.mdx
+++ b/src/content/troubleshooting/faq/chromatic-draft-pr.mdx
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # 👇 Makes sure Chromatic can review the full git history
           fetch-depth: 0
           # 👇 Tells the checkout which commit hash to reference
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
-          node-version: 24.15.0
+          node-version: 24.19.0
       # 👇 Install dependencies with the same package manager used in the project (replace it as needed), e.g. yarn, npm, pnpm
       - name: Install dependencies
         run: npm ci

--- a/src/content/troubleshooting/faq/chromatic-ui-related-commits.mdx
+++ b/src/content/troubleshooting/faq/chromatic-ui-related-commits.mdx
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: 24.15.0
+          node-version: 24.19.0
       - name:
           Install dependencies
           # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.

--- a/src/content/vitest/sharding.md
+++ b/src/content/vitest/sharding.md
@@ -28,14 +28,14 @@ jobs:
         shard: [1, 2]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      image: mcr.microsoft.com/playwright:v1.62.0-noble
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
-          node-version: 24.18.0
+          node-version: 24.19.0
       - name: Install dependencies
         run: npm ci
       - name: Run Vitest tests
@@ -58,9 +58,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
-          node-version: 24.18.0
+          node-version: 24.19.0
       - name: Install dependencies
         run: npm ci
 
@@ -99,7 +99,7 @@ before_script:
 Vitest:
   stage: UI_Tests
   needs: []
-  image: mcr.microsoft.com/playwright:v1.61.1-noble
+  image: mcr.microsoft.com/playwright:v1.62.0-noble
   parallel: 2
   script:
     - npx vitest run --shard=$CI_NODE_INDEX/$CI_NODE_TOTAL
@@ -126,10 +126,10 @@ version: 2.1
 executors:
   vitest-noble-development:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.61.1-noble
+      - image: mcr.microsoft.com/playwright:v1.62.0-noble
   chromatic-ui-testing:
     docker:
-      - image: cimg/node:24.18.0
+      - image: cimg/node:24.19.0
 
 jobs:
   Vitest:
@@ -204,7 +204,7 @@ pipeline {
         stage('Shard #1') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
+              image 'mcr.microsoft.com/playwright:v1.62.0-noble'
               reuseNode true
             }
           }
@@ -224,7 +224,7 @@ pipeline {
         stage('Shard #2') {
           agent {
             docker {
-              image 'mcr.microsoft.com/playwright:v1.61.1-noble'
+              image 'mcr.microsoft.com/playwright:v1.62.0-noble'
               reuseNode true
             }
           }
@@ -282,7 +282,7 @@ blocks:
           os_image: ubuntu2404
         containers:
           - name: Vitest
-            image: mcr.microsoft.com/playwright:v1.61.1-noble
+            image: mcr.microsoft.com/playwright:v1.62.0-noble
       jobs:
         - name: Run Vitest
           commands:
@@ -300,7 +300,7 @@ blocks:
     task:
       prologue:
         commands:
-          - sem-version node 24.18.0
+          - sem-version node 24.19.0
           - artifact pull workflow .vitest
       secrets:
         - name: CHROMATIC_PROJECT_TOKEN
@@ -322,7 +322,7 @@ image: node:krypton
 - run:
     name: "Vitest"
     displayName: "Run Vitest tests"
-    container: mcr.microsoft.com/playwright:v1.61.1-noble
+    container: mcr.microsoft.com/playwright:v1.62.0-noble
     options:
       parallel: 2
       artifacts:


### PR DESCRIPTION
With this pull request, the following items were updated to match the latest stable versions:
- Playwright and Cypress Docker images
- Node images

Additionally, other references to the action's versions were also updated across all the documentation (including React Native)