### PR TITLE
docs(turbosnap): cover every bail reason the usage report can show

### DIFF
--- a/src/content/turbosnap/troubleshooting-turbosnap.mdx
+++ b/src/content/turbosnap/troubleshooting-turbosnap.mdx
@@ -68,9 +68,25 @@ In the case of merge commits, Chromatic does not know ahead of time which side o
 
 TurboSnap is compatible with squash and merge rebasing as of version 6.6+. Please update your package to get support.
 
+## Why didn't TurboSnap run on my build?
+
+"TurboSnap bailed" and "TurboSnap never ran" are different situations with different fixes, and the usage report doesn't always tell them apart. Work out which one you're looking at before you start troubleshooting.
+
+| Bail reason column                                                                      | What happened                                                                                        |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| One of the [reasons below](#what-do-the-turbosnap-bail-reasons-in-my-usage-report-mean) | TurboSnap ran, but couldn't confirm anything was unchanged, so every test in the build was captured. |
+| `unavailable`                                                                           | Your plan doesn't include TurboSnap, so it never ran. No configuration change will alter that.       |
+| Empty                                                                                   | Either TurboSnap ran and copied what it could, or it wasn't enabled for that build.                  |
+
+An empty column doesn't distinguish those last two. To tell them apart, open the build in Chromatic and check the TurboSnap status in the test summary. Its tooltip says whether TurboSnap applied, bailed, or was disabled for that build.
+
 ## What do the TurboSnap bail reasons in my usage report mean?
 
-Your [usage data (CSV report)](/docs/billing/usage-reports#export-usage-data-as-a-csv) can help you faster identify opportunities to improve your TurboSnap configuration. The "TurboSnaps Bail Reason" column tells you what caused TurboSnap triggered a full rebuild. Here's what each reason means:
+Your [usage data (CSV report)](/docs/billing/usage-reports#export-usage-data-as-a-csv) can help you identify opportunities to improve your TurboSnap configuration. The **TurboSnap Bail Reason** column tells you what caused TurboSnap to bail and trigger a full rebuild. The **TurboSnap effectiveness** chart in the [Trends dashboard](/docs/optimize-usage) segments bails by these same reasons.
+
+Most reasons point to something in your setup you can change. `unavailable` and `missingStatsFile` are the exceptions, explained in their entries below.
+
+Here's what each reason means:
 
 ### `changedExternalFiles`
 
@@ -108,7 +124,9 @@ TurboSnap is having issues retrieving your git history. This commonly happens wh
 
 TurboSnap bailed due to missing stats file.
 
-Since the stats file is needed for TurboSnap to analyze your dependencies, make sure your Storybook script includes `--stats-json`.
+This reason comes from Chromatic CLI versions before 10.6.0. Newer versions fail the build with an error message instead of bailing, so it only appears in usage reports covering builds that ran on an older CLI.
+
+The fix is the same either way. Since the stats file is needed for TurboSnap to analyze your dependencies, make sure your Storybook script includes `--stats-json`.
 
 ### `noAncestorBuild`
 
@@ -121,3 +139,9 @@ This bail reason is reserved for when no ancestor build is found at all for a co
 TurboSnap bailed because the commit is a rerun of a previous build, based on the baseline build having the same commit and branch name.
 
 Most reruns are intentional, but if you weren't expecting the ones you're seeing, this may indicate you need to check your CI workflow to see what could be kicking off an additional build for the same commit.
+
+### `unavailable`
+
+TurboSnap didn't run because your plan doesn't include it.
+
+This isn't a configuration problem, and no change to your Chromatic script will resolve it. Review your plan on the [billing page](/docs/billing). In Chromatic, the TurboSnap status on an affected build links through to the project's manage page, where availability is shown.

--- a/src/content/turbosnap/troubleshooting-turbosnap.mdx
+++ b/src/content/turbosnap/troubleshooting-turbosnap.mdx
@@ -70,12 +70,12 @@ TurboSnap is compatible with squash and merge rebasing as of version 6.6+. Pleas
 
 ## Why didn't TurboSnap run on my build?
 
-"TurboSnap bailed" and "TurboSnap never ran" are different situations with different fixes, and the usage report doesn't always tell them apart. Work out which one you're looking at before you start troubleshooting.
+The usage report shows whether TurboSnap actually ran, and if it didn’t, why.
 
 | Bail reason column                                                                      | What happened                                                                                        |
 | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | One of the [reasons below](#what-do-the-turbosnap-bail-reasons-in-my-usage-report-mean) | TurboSnap ran, but couldn't confirm anything was unchanged, so every test in the build was captured. |
-| `unavailable`                                                                           | Your plan doesn't include TurboSnap, so it never ran. No configuration change will alter that.       |
+| `unavailable`                                                                           | TurboSnap isn't available for your account yet. It becomes available after 10 builds from CI.        |
 | Empty                                                                                   | Either TurboSnap ran and copied what it could, or it wasn't enabled for that build.                  |
 
 An empty column doesn't distinguish those last two. To tell them apart, open the build in Chromatic and check the TurboSnap status in the test summary. Its tooltip says whether TurboSnap applied, bailed, or was disabled for that build.
@@ -142,6 +142,8 @@ Most reruns are intentional, but if you weren't expecting the ones you're seeing
 
 ### `unavailable`
 
-TurboSnap didn't run because your plan doesn't include it.
+TurboSnap didn't run because it isn't available for your account yet.
 
-This isn't a configuration problem, and no change to your Chromatic script will resolve it. Review your plan on the [billing page](/docs/billing). In Chromatic, the TurboSnap status on an affected build links through to the project's manage page, where availability is shown.
+TurboSnap becomes available once a project has run at least 10 builds from CI, and it stays available for the whole account from then on. Until that happens, builds that ask for TurboSnap record this reason and capture every test.
+
+This isn't a configuration problem, so there's nothing to change in your Chromatic script. Keep running builds in CI. If you've passed 10 builds from CI and TurboSnap still isn't available, check that the project has UI Tests or UI Review enabled, since it won't become available for projects that only publish Storybook.


### PR DESCRIPTION
Add the `unavailable` bail reason, which the CSV can surface but the page never documented. It is a plan entitlement condition rather than a misconfiguration, so its entry points at billing instead of a config fix.

Reframe `missingStatsFile` as legacy: the CLI has failed the build with an error instead of bailing since v10.6.0, so it only appears in usage reports covering builds that ran on an older CLI.

Add "Why didn't TurboSnap run on my build?" above the list. An empty bail reason cell means either TurboSnap applied or it was never enabled, and the CSV cannot distinguish the two, so the section sends readers to the build's TurboSnap tooltip.

Fix the column name (TurboSnaps Bail Reason -> TurboSnap Bail Reason) and the grammar of the sentence naming it.

The existing bail-reason anchor is unchanged; five pages link into it.

Refs CHDX-1126