### PR TITLE
docs: fix account ownership guidance and ignored FAQ frontmatter

### DIFF
--- a/src/content/access/access.md
+++ b/src/content/access/access.md
@@ -114,7 +114,7 @@ When you have a fork of a private organization owned repository, that forked rep
 
 Email and password authentication is available on all accounts. It's a popular authentication method for [external collaborators](/docs/access/collaborators#external-collaborators) like designers, PMs, and other stakeholders.
 
-If you're setting up Chromatic for your team as the account owner or administrator, there are some boundaries to be aware of:
+If you're setting up Chromatic for your team, there are some boundaries to be aware of:
 
 - Email accounts can use Chromatic as normal
 - [Collaborators](/docs/access/collaborators) are manually managed
@@ -161,9 +161,9 @@ You can link a project during the project creation process or afterward on the p
 
 If you encounter an `<unknown>` project, this means Chromatic can no longer connect it to your Git repository.
 
-To refresh the Git access token and reconnect the `<unknown>` project, request one of the account owners to log out and log back into Chromatic.
+Each project syncs using one collaborator's access token. Open the project's **Manage** page » **Configure** tab to see whose token it's using. That person can sign out of Chromatic and sign back in with the Git provider to refresh it.
 
-Alternatively, replace the Git token from the `Configure` tab on the `Manage` page of your project.
+Anyone with Developer access or higher and a connected Git account can take over instead, by selecting **Replace with your token** on the same tab.
 
 </details>
 

--- a/src/content/access/collaborators.md
+++ b/src/content/access/collaborators.md
@@ -55,17 +55,18 @@ Single Sign-On (SSO) is available to enterprise customers. Learn more [here](/do
 
 Collaborate on billing, usage, and permissions by syncing your organization with GitHub, Bitbucket, or GitLab.
 
-For email and password accounts, the user who created the account is the only one who can sign in to manage billing. To give a teammate billing access, see below. For SSO accounts, contact your company's SSO administrator to manage billing.
+For email and password accounts, the user who created the account is the only one who can sign in to manage billing. On SSO accounts and unlinked organization accounts, the Billing role is set by Chromatic — see below.
 
 <details>
 <summary>How can I give someone billing access?</summary>
 
-If you have an unlinked organization account and need access to billing, please email us at **support@chromatic.com** with your email address.
+If you have an unlinked organization or SSO account and need billing access for someone, email us at **support@chromatic.com** with their email address.
 
 **Note:**
 
 - Billing users cannot be added to Git-linked accounts. Linked accounts rely on the connected Git provider to manage permissions. Users would need org-level permissions granted within the git provider to access billing.
 - Git-linked users cannot be set as Billing users for unlinked accounts. Git-linked user permissions depend on git providers.
+- On SSO accounts with directory sync, roles come from your identity provider. If your IdP later changes someone's role, it overwrites the role we set, so assigning the Billing role in your IdP is the durable option.
 
 </details>
 

--- a/src/content/access/collaborators.md
+++ b/src/content/access/collaborators.md
@@ -55,16 +55,16 @@ Single Sign-On (SSO) is available to enterprise customers. Learn more [here](/do
 
 Collaborate on billing, usage, and permissions by syncing your organization with GitHub, Bitbucket, or GitLab.
 
-For email and password accounts, only the account owner can login to access billing information. For SSO accounts, contact your company's SSO administrator to manage billing.
+For email and password accounts, the user who created the account is the only one who can sign in to manage billing. To give a teammate billing access, see below. For SSO accounts, contact your company's SSO administrator to manage billing.
 
 <details>
 <summary>How can I give someone billing access?</summary>
 
-If you have an email/password user account and need access to billing, please email us at **support@chromatic.com** with your email address.
+If you have an unlinked organization account and need access to billing, please email us at **support@chromatic.com** with your email address.
 
 **Note:**
 
-- Billings users cannot be added to Git-linked accounts. Linked accounts rely on the connected Git provider to manage permissions. Users would need org-level permissions granted within the git provider to access billing.
+- Billing users cannot be added to Git-linked accounts. Linked accounts rely on the connected Git provider to manage permissions. Users would need org-level permissions granted within the git provider to access billing.
 - Git-linked users cannot be set as Billing users for unlinked accounts. Git-linked user permissions depend on git providers.
 
 </details>
@@ -138,6 +138,8 @@ On the Enterprise plan with SSO and directory sync (SCIM), additional organizati
 Projects must have at least one owner. The `owner` role is automatically assigned to the first user in a Chromatic project.
 
 Transfer ownership by assigning another collaborator as an owner and then reassigning yourself another role.
+
+This transfers a single project. Chromatic accounts have no owner role — see [how do I transfer account ownership to another user?](/docs/faq/transfer-ownership/)
 
 #### View your role
 

--- a/src/content/troubleshooting/faq/chromatic-free-plan.mdx
+++ b/src/content/troubleshooting/faq/chromatic-free-plan.mdx
@@ -2,9 +2,9 @@
 sidebar: { hide: true }
 title: Is there a trial period on Chromatic's free plan?
 section: account
-section order: 5
+sectionOrder: 5
 ---
 
 # Is there a trial period on Chromatic's free plan?
 
-There is no trial period at Chromatic - users can enjoy the features of the free plan indefinitely without worrying about the subscription ending.
+No. The free plan has no trial period and doesn't expire. You can use it indefinitely.

--- a/src/content/troubleshooting/faq/connect-git-user-to-chromatic-user.mdx
+++ b/src/content/troubleshooting/faq/connect-git-user-to-chromatic-user.mdx
@@ -4,30 +4,19 @@ title: How do I link my Git account to my Chromatic account?
 section: account
 ---
 
-# Link Git account to Chromatic account
+# How do I link my Git account to my Chromatic account?
 
-## Link your Git account to your Chromatic account
+If you registered with an email and password, you can link your account to a Git provider such as GitHub, GitLab, or Bitbucket.
 
-If you registered your Chromatic account using an email and password, you can link it to a Git provider like GitHub or BitBucket.
+1. Open your [profile page](https://www.chromatic.com/profile).
+2. Under **Connect**, select your Git provider.
+3. Follow the steps on your provider's side to authorize Chromatic.
 
-1. Open the Profile page: https://www.chromatic.com/profile
-2. Below `Connect`, tab the Git provider of your choise and follow the steps on Git side to authorize Chromatic to link both users.
+You can connect more than one Git provider.
 
-You can connect to more than one Git provider.
-
-### Error when trying to connect a Git account
-
-If you encounter an `Authentication error: Failed to login as OAuth user` while trying to connect to a Git account, it means a Chromatic account already exists with that particular Git account. You probably created that account by mistake, so you can delete it:
-
-1. Log out of your current account
-2. Go to the login page: https://www.chromatic.com/start
-3. Press Connect with the Git provider. Pick of your choice and access the second account.
-4. Open the Profile page: https://www.chromatic.com/profile
-5. Scroll down and [remove the user](/docs/faq/delete-my-profile/).
-
-Then go back to the initial account and try to connect the Git account via the profile page.
+If you see an error saying the Git account is already connected to another Chromatic profile, see [why is my Git account already connected to another Chromatic profile?](/docs/faq/failed-to-login/)
 
 ## Unlink your Git account
 
-1. Open the Profile page: https://www.chromatic.com/profile
-2. Press `Disconnect`
+1. Open your [profile page](https://www.chromatic.com/profile).
+2. Select **Disconnect** next to the provider you want to remove.

--- a/src/content/troubleshooting/faq/delete-my-profile.mdx
+++ b/src/content/troubleshooting/faq/delete-my-profile.mdx
@@ -6,12 +6,20 @@ section: account
 
 # How do I delete my profile?
 
-To delete your Chromatic profile, you'll need to do the following:
+1. Open your [profile page](https://www.chromatic.com/profile).
+2. Under **Danger zone**, select **Delete**.
+3. Confirm the deletion.
 
-1. Open your Chromatic profile: https://www.chromatic.com/profile
+If you signed up with an email and password, Chromatic asks for that password before deleting.
 
-2. In the `Danger zone`, press `Delete`
+## What deletion removes
 
-3. Confirm that you want to delete your profile and remove all your projects
+Deleting your profile permanently deletes the projects on your personal account. They can't be recovered.
 
-If you would like to transfer projects over to a different account before the deletion of your account, please use our **in-app chat** to get in touch, or email us at **support@chromatic.com**.
+Projects on organization accounts aren't deleted. Your profile loses access to them, and the projects stay with the organization.
+
+<div class="callout">
+
+⚠️ **We usually can't move projects to another account for you.** If your personal account holds projects you still need, contact us via our **in-app chat** or email [support@chromatic.com](mailto:support@chromatic.com) before you delete anything.
+
+</div>

--- a/src/content/troubleshooting/faq/edit-billing-email.mdx
+++ b/src/content/troubleshooting/faq/edit-billing-email.mdx
@@ -2,13 +2,14 @@
 sidebar: { hide: true }
 title: How can I edit my billing email?
 section: account
-section order: 6
+sectionOrder: 6
 ---
 
 # How can I edit my billing email?
 
-Chromatic sets the account's billing email address to the email address of the person who signed up to the plan. Chromatic will send all billing and account-related emails to this address while continuing to send in-app notifications to the relevant person's email address. To edit your billing email, please do the following:
+Chromatic sets your billing email to the address of the person who signed up for the plan. All billing and account-related emails go to that address. In-app notifications continue to go to each person's own email address.
 
-1. Navigate to the `billing` tab in the sidebar of your account.
+To edit your billing email:
 
-2. Select `Change email`
+1. Go to the **Billing** tab in your account sidebar.
+2. Select **Change email**.

--- a/src/content/troubleshooting/faq/failed-to-login.mdx
+++ b/src/content/troubleshooting/faq/failed-to-login.mdx
@@ -7,7 +7,7 @@ sectionOrder: 5
 
 # Why is my Git account already connected to another Chromatic profile?
 
-A Git provider account can only be connected to one Chromatic profile at a time. You'll see this when you try to connect one that's already attached elsewhere:
+A Git provider account can only be connected to one Chromatic profile at a time. You'll see an error like this when you try to connect one that's already attached elsewhere:
 
 ```plain
 This GitHub account is already connected to another Chromatic profile,

--- a/src/content/troubleshooting/faq/failed-to-login.mdx
+++ b/src/content/troubleshooting/faq/failed-to-login.mdx
@@ -1,16 +1,48 @@
 ---
 sidebar: { hide: true }
-title: Why am I receiving a failed to login as OAuth user error ?
+title: Why is my Git account already connected to another Chromatic profile?
 section: account
-section order: 5
+sectionOrder: 5
 ---
 
-# Why am I receiving a failed to login as OAuth user error ?
+# Why is my Git account already connected to another Chromatic profile?
 
-If you're encountering issues with linking your Git provider to Chromatic, one of the most common reasons for this error is due to existing duplicate accounts.
+A Git provider account can only be connected to one Chromatic profile at a time. You'll see this when you try to connect one that's already attached elsewhere:
 
-The first step in resolving this issue is identifying any previous accounts you may have with Chromatic.
+```plain
+This GitHub account is already connected to another Chromatic profile,
+but can only be connected to one.
+```
 
-Once you've identified a potential duplicate account, the next step is to log into Chromatic using the account that's causing the issue.
+## You have a second Chromatic profile
 
-If you are unable to find the account, please contact support via our **in-app chat** or email us at **support@chromatic.com** so we can assist you further.
+The usual cause. Most people get here after signing up twice: once with a Git provider, once with an email and password.
+
+Decide which profile you're keeping before deleting anything. Usually it's the Git-linked one, because that's where your projects and build history already are.
+
+### Keeping the Git-linked profile
+
+Sign out, then sign in at [chromatic.com/start](https://www.chromatic.com/start) with your Git provider. That takes you to the Git-linked profile, and there's nothing left to connect.
+
+If you don't want the email and password profile, sign in to it and [delete it](/docs/faq/delete-my-profile).
+
+### Keeping the email and password profile
+
+The Git-linked profile has to go first, since the Git account can't be attached to two profiles at once.
+
+1. Sign out of your current profile.
+2. Sign in at [chromatic.com/start](https://www.chromatic.com/start) with the Git provider that's causing the error.
+3. Open your [profile page](https://www.chromatic.com/profile) and [delete that profile](/docs/faq/delete-my-profile).
+4. Sign back in to the profile you're keeping, then connect the Git provider from your profile page.
+
+Chromatic asks for the password before deleting a profile that was created with an email and password.
+
+## The Git account is connected to a SAML profile
+
+You can't fix this one yourself. If the Git account is attached to a profile on a [SAML account](/docs/access/sso), that profile has to be removed first.
+
+Use our **in-app chat** to contact us or email us at [support@chromatic.com](mailto:support@chromatic.com). Tell us the Git provider and the username or email you're connecting.
+
+Removing a profile is permanent, so we'll confirm what's on it before doing anything.
+
+Once we've removed it, sign out — or clear your cookies for `chromatic.com` — before you sign in with your Git provider again. An old session can send you back to the profile you just left, which looks like the fix didn't work.

--- a/src/content/troubleshooting/faq/how-do-i-turn-off-turbosnap.mdx
+++ b/src/content/troubleshooting/faq/how-do-i-turn-off-turbosnap.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar: { hide: true }
 title: How do I turn off TurboSnap?
-section: turbosnap
+section: turboSnap
 ---
 
 # How do I turn off TurboSnap?

--- a/src/content/troubleshooting/faq/share-billing.mdx
+++ b/src/content/troubleshooting/faq/share-billing.mdx
@@ -2,13 +2,11 @@
 sidebar: { hide: true }
 title: Can billing be shared across multiple Chromatic accounts?
 section: account
-section order: 6
+sectionOrder: 6
 ---
 
 # Can billing be shared across multiple Chromatic accounts?
 
-Chromatic no longer supports sharing a single self-serve paid plan across multiple accounts (for example, across different GitHub organizations).
-New self-serve subscriptions can be linked to one account only, and usage can't be combined across accounts.
+No, not on a self-serve plan. Chromatic no longer supports sharing a single self-serve paid plan across multiple accounts, such as across different GitHub organizations. New self-serve subscriptions can be linked to one account only, and usage can't be combined across accounts.
 
-For teams that need multi-account billing or consolidated usage, this capability is available through
-an Enterprise plan. Please reach out to our sales team for more information.
+Multi-account billing and consolidated usage are available on an [Enterprise plan](https://www.chromatic.com/enterprise). Contact our sales team for details.

--- a/src/content/troubleshooting/faq/transfer-ownership.mdx
+++ b/src/content/troubleshooting/faq/transfer-ownership.mdx
@@ -2,9 +2,33 @@
 sidebar: { hide: true }
 title: How do I transfer account ownership to another user?
 section: account
-section order: 5
+sectionOrder: 5
 ---
 
 # How do I transfer account ownership to another user?
 
-To transfer ownership, you will need to assign another collaborator with the owner role - please note they must be a collaborator within the organization account (via Git provider). If you have an individual account and want to transfer it to another user, please reach out to us using our **in-app chat** or email us at **support@chromatic.com**.
+Chromatic accounts don't have an owner role, so there's nothing to hand over directly. What to do depends on the account type.
+
+Looking to hand off a single project? See [project ownership](/docs/access/collaborators#project-ownership).
+
+## Organization accounts linked to a Git provider
+
+Access comes from your GitHub organization, GitLab group, or Bitbucket workspace. Everyone in it is a Member in Chromatic, so there's no owner to reassign — change who has access in your Git provider instead.
+
+One thing is tied to a specific person: the Git provider API token Chromatic uses to sync your organization's details and permissions. If that person leaves or loses access, another member takes it over themselves:
+
+1. Sign in to Chromatic with the same Git provider.
+2. Open your organization's **Settings** page.
+3. Under **API token**, select **Replace with your token**.
+
+This can only be done by the person taking the token over, and it can't be undone.
+
+## Enterprise accounts with SSO
+
+Organization roles come from your identity provider. An Admin can change a member's role to Billing, Member, or Viewer on the Settings page, but making someone an Admin has to happen in your identity provider. Every account keeps at least one Admin. See [organization roles](/docs/access/teams#organization-roles).
+
+## Individual accounts
+
+There's no self-serve way to move an email and password account, or a personal Git account, to someone else. Use our **in-app chat** to contact us or email us at [support@chromatic.com](mailto:support@chromatic.com). Tell us the account and who should have it, and we'll go through the options with you.
+
+Moving the subscription is a separate step — see [how do I transfer my account's subscription to another account?](/docs/faq/transfer-subscription/)

--- a/src/content/troubleshooting/faq/transfer-subscription.mdx
+++ b/src/content/troubleshooting/faq/transfer-subscription.mdx
@@ -2,11 +2,11 @@
 sidebar: { hide: true }
 title: How do I transfer my account's subscription to another account?
 section: account
-section order: 4
+sectionOrder: 4
 ---
 
 # How do I transfer my account's subscription to another account?
 
-If you would like to transfer your subscription to another account, please get in touch with our **in-app chat** or email us at **support@chromatic.com**, providing your account details and the new account to which you would like the subscription transferred.
+To transfer your subscription to another account, use our **in-app chat** to contact us or email us at [support@chromatic.com](mailto:support@chromatic.com). Include your account details and the account you want the subscription transferred to.
 
-You can learn more about our subscriptions here: https://www.chromatic.com/pricing
+Learn more about [Chromatic's plans and pricing](https://www.chromatic.com/pricing).


### PR DESCRIPTION
Eleven pages in `troubleshooting/faq/` and `access/` had frontmatter the schema was silently ignoring, wrong guidance, or both. Five commits, reviewable in order.

Tracked in [SUP-510](https://linear.app/chromaui/issue/SUP-510).

## 1. Ignored frontmatter keys (5 files)

`section order:` isn't a schema key, so four account FAQs never got the sidebar order they specified. `section: turbosnap` orphaned one page from the four siblings using `turboSnap`. Prose on the same five pages is tightened; no guidance changed.

**This reorders the account FAQ section.** Six files now sit at `sectionOrder: 5`. Renumbering them is an editorial call I left alone.

## 2. Git account and profile deletion (3 files)

- `failed-to-login` was titled after `failed to login as OAuth user` — a server log line customers never see. Retitled after the message they do see, now covers both causes, and leads with the common case: people usually want to delete the email and password profile, not the git-linked one.
- `delete-my-profile` said deletion removes "all your projects". It only deletes personal-account projects; organization projects stay and the profile loses access. It also promised we'd move projects first, which we usually can't.
- `connect-git-user-to-chromatic-user` duplicated the same error using the stale string, so it links out instead. Two typos fixed, GitLab added.

## 3. Account vs project ownership (2 files)

`transfer-ownership` answered a question about *account* ownership with the procedure for transferring a *project*. There is no account-level owner role — account roles are Admin, Billing, Member and Viewer; Owner belongs to the project roles. The page's one instruction couldn't be followed.

Now split by account type, including the provider API token handoff, which is the real answer when whoever set up the account leaves. `collaborators.md` gains a reciprocal link and drops its own "account owner" claim about billing.

## 4. Who grants billing access (1 file)

`collaborators.md` said to contact your company's SSO administrator to manage billing. Nothing routes billing through the identity provider — it supplies a role string that maps once to a Chromatic role, which then feeds the same permission matrix as everyone else.

Granting the Billing role is a support action on both SSO and unlinked accounts. Unlinked accounts have no self-serve path. On SSO accounts a role set through the UI isn't durable: the membership access level is overwritten from the IdP role on the next role change or directory sync, so the note says to assign it in the IdP instead. The billing-access `<details>` is now the single place carrying the instruction.

## 5. The last "account owner" references (1 file)

`access.md` used the phrase twice. The email setup sentence just drops it — the role did no work there.

The `<unknown>` project remedy was wrong about who can fix it. A project syncs through **its own** token holder, a per-project field distinct from the account's, and signing back in only refreshes the token of the person who authenticated. So "request one of the account owners to log out and log back in" named the wrong role, and re-login by anyone other than that one collaborator does nothing. It now points at the Configure tab, which names the collaborator whose token the project uses, and gives the takeover path with the button's real label ("Replace with your token", not "replace the Git token").

## Verification

Every correction is verified against `chromatic/monorepo` rather than inferred — role enums, the membership sync path, the deletion workflow, both token holder fields, and the SAML role sync. File and line references are in SUP-510. The SAML login remedy in commit 2 comes from support experience ([T-1386](https://app.plain.com/workspace/w_01KP92JF753VC7QAX2YKNVAR9X/thread/th_01KZP8KDY3C5S0YQTYEFSME1BV/)), not from code.

`pnpm build` passes (226 pages) and `pnpm test:unit` passes (41 tests). All new link targets resolve in `dist`. `grep -rni "account owner" src/content` now returns only the `transfer-ownership` title and the sentence stating the role doesn't exist.

## Reviewer notes

- **"Unlinked organization" is undefined in the docs** until [SUP-499](https://linear.app/chromaui/issue/SUP-499) ships the account-types section. Deliberate — defining it here would duplicate that work.