### PR TITLE
docs(turbosnap): document bypassed builds and their billing impact

### DIFF
--- a/src/content/account/billing.mdx
+++ b/src/content/account/billing.mdx
@@ -26,10 +26,14 @@ Not at this time. We currently only support monthly payments for our self-serve 
 
 ## Snapshots
 
-The monthly bill is calculated based on the number of billed [snapshots](/docs/snapshots). There are two types of snapshots:
+The monthly bill is calculated based on the number of billed [snapshots](/docs/snapshots). There are three types of snapshots:
 
 - **Captured (1 billed snapshot):** Chromatic performs the full suite of work, including taking screenshots or capturing accessibility data, and running diffs.
-- **Turbosnap (0.2 billed snapshot):** Chromatic identifies tests that have no code changes associated with them or their dependencies and copies over the existing snapshots from previous baselines for them.
+- **Turbosnap**
+  - **Copied (0.2 billed snapshots):** Chromatic identifies tests that have no code changes associated with them or their dependencies and copies over the existing snapshots from previous baselines for them.
+  - **Bypassed (0 billed snapshots):** the build has no changes in any test's dependencies at all, so Chromatic bypasses all snapshots.
+
+Copied and bypassed snapshots are both produced by [TurboSnap](/docs/turbosnap), and together they're referred to as **turbosnaps**. See [copied and bypassed snapshots](/docs/turbosnap#bypassed-builds) for how Chromatic decides between them.
 
 ## How we count billed snapshots
 
@@ -63,6 +67,10 @@ billed snapshots from turbosnaps = turbosnaps * 0.2
 
 billed snapshots = visual snapshots + accessibility snapshots + billed snapshots from turbosnaps
 ```
+
+#### Bypassing snapshots
+
+Builds where _nothing_ in any test's dependencies changed are the exception. Chromatic bypasses every snapshot on such a build rather than copying it, so the build incurs no billed snapshots and drops out of the calculation entirely. See [copied and bypassed snapshots](/docs/turbosnap#bypassed-builds).
 
 ### Billed snapshots are counted at the account level
 

--- a/src/content/account/optimize-usage.mdx
+++ b/src/content/account/optimize-usage.mdx
@@ -87,7 +87,7 @@ Use the Billed Snapshots per Build chart to compare the periods before and after
 
 Snapshot Billing Rate is billed snapshots divided by total snapshots. It shows whether your usage is becoming more or less efficient over time. When you first set up Chromatic, the rate starts at `1.0` because a full cost snapshot is captured for every test.
 
-[TurboSnap](/docs/turbosnap) lowers your Snapshot Billing Rate by using changed files to determine which stories need new snapshots. It _copies_ or _bypasses_ snapshots for stories it determines could not have changed and these are billed at a lower rate.
+[TurboSnap](/docs/turbosnap) lowers your Snapshot Billing Rate by using changed files to determine which stories need new snapshots. It _copies_ or [_bypasses_](/docs/turbosnap#bypassed-builds) snapshots for stories it determines could not have changed and these are billed at a lower rate.
 
 - Captured costs `1.0` billed snapshot.
 - Copied (via TurboSnap) costs `0.2` billed snapshots.

--- a/src/content/turbosnap/turbosnap.mdx
+++ b/src/content/turbosnap/turbosnap.mdx
@@ -30,7 +30,7 @@ This is a special case of TurboSnap. If a build has no changes in _any_ story's 
 Bypassed snapshots require Chromatic CLI 17.7.0 or later. A build is bypassed when all of the following are true:
 
 - No files in any story's dependency graph changed.
-- The build has exactly one [ancestor build](/docs/branching-and-baselines#find-the-ancestor-builds) ([merge commits](#merge-commits) have two ancestors, so they are never bypassed).
+- The build has exactly one [ancestor build](/docs/branching-and-baselines#find-the-ancestor-builds) (a [merge commit](#merge-commits) on an otherwise unchanged branch will typically only have a single ancestor as all other builds on the branch will have been bypassed).
 - The ancestor build is passing or accepted, or it's on the same branch as the current build.
 - The build did not come from the [Visual Tests Addon](/docs/visual-tests-addon) running locally.
 

--- a/src/content/turbosnap/turbosnap.mdx
+++ b/src/content/turbosnap/turbosnap.mdx
@@ -23,6 +23,23 @@ Chromatic will _not_ capture a new snapshot for stories that do not have associa
 
 If you denied any [UI Tests](/docs/quickstart#4-review-changes) on the ancestor build, Chromatic will always recapture those stories even if TurboSnap would otherwise skip them. This is particularly useful for diagnosing [unstable tests](/docs/unstable-tests#improve-test-stability).
 
+### Bypassed builds
+
+This is a special case of TurboSnap. If a build has no changes in _any_ story's dependency graph, Chromatic bypasses every snapshot on that build rather than copying them. The build incurs zero billed snapshots.
+
+Bypassed snapshots require Chromatic CLI 17.7.0 or later. A build is bypassed when all of the following are true:
+
+- No files in any story's dependency graph changed.
+- The build has exactly one [ancestor build](/docs/branching-and-baselines#find-the-ancestor-builds) ([merge commits](#merge-commits) have two ancestors, so they are never bypassed).
+- The ancestor build is passing or accepted, or it's on the same branch as the current build.
+- The build did not come from the [Visual Tests Addon](/docs/visual-tests-addon) running locally.
+
+<div class="aside">
+
+Only the dependency graph decides this, not the nature of the change. If a file is in a story's dependency graph, editing it prevents the build from being bypassed even when the edit cannot affect the UI. For instance, adding a comment to a CSS file that a story imports still triggers a capture.
+
+</div>
+
 ### Full rebuilds
 
 Certain code changes have the potential to impact all stories. To avoid false positives, we re-capture everything in the following situations:
@@ -154,19 +171,25 @@ Things get a little more complicated when TurboSnap tries to locate the commit f
 
 ## Pricing
 
-Each snapshot incurs billed snapshots: captured snapshots cost 1 billed snapshot and turbosnaps cost 0.2 billed snapshots. The billed snapshot count is used to calculate your monthly bill.
+Each snapshot incurs billed snapshots, and how many depends on the work Chromatic had to do. The billed snapshot count is used to calculate your monthly bill.
+
+| Snapshot type                | Cost (billed snapshots) |
+| ---------------------------- | ----------------------- |
+| Captured                     | 1                       |
+| [Copied](#how-it-works)      | 0.2                     |
+| [Bypassed](#bypassed-builds) | 0                       |
 
 ### How turbosnaps are billed
 
-By enabling TurboSnap, Chromatic checks for stories with no associated code changes. Instead of capturing new snapshots, it copies snapshots from existing baselines. This uses fewer infrastructure resources, and we pass these savings on to you by billing each turbosnap at 1/5th the cost of a captured snapshot (`0.2`).
+By enabling TurboSnap, Chromatic checks for stories with no associated code changes. Instead of capturing new snapshots, it copies snapshots from existing baselines. This uses fewer infrastructure resources, and we pass these savings on to you by billing each copied snapshot at 1/5th the cost of a captured snapshot (`0.2`).
 
 The remaining stories on that build are captured as usual and cost 1 billed snapshot each.
 
 For example, consider a Storybook with 50 stories. If your code changes impact 10 stories, Chromatic will capture new snapshots for those 10 stories. The cost of that build will be 18 billed snapshots:
 
 - 10 captured snapshots (1 x 10 = 10 billed snapshots)
-- 40 turbosnaps (.2 x 40 = 8 billed snapshots)
+- 40 copied snapshots (.2 x 40 = 8 billed snapshots)
 
 Check out the [billing docs](/docs/billing#with-turbosnap-enabled) for more details.
 
-Note, stories excluded by [`OnlyStoryNames`](/docs/configure#onlystorynames) and [`OnlyStoryFiles`](/docs/configure#onlystoryfiles) are also billed at the turbosnap rate.
+Note, stories excluded by [`OnlyStoryNames`](/docs/configure#onlystorynames) and [`OnlyStoryFiles`](/docs/configure#onlystoryfiles) are also billed at the copied snapshot rate.


### PR DESCRIPTION
- Add a "Bypassed builds" section covering the conditions for a bypass
- Correct pricing to the three-way split (captured 1, copied 0.2, bypassed 0)
- Link the copied/bypassed vocabulary already used by the Trends dashboard to the new definitions
