### PR TITLE
docs(mcp): add authentication troubleshooting entries

### DIFF
--- a/src/content/collaborate/mcp.mdx
+++ b/src/content/collaborate/mcp.mdx
@@ -248,3 +248,12 @@ Editing the wrong file is a common cause of "my changes had no effect."
 To confirm the server itself is reachable before debugging your config, open the MCP URL in a browser: `https://<BRANCH>--<APP-ID>.chromatic.com/mcp`.
 
 </details>
+
+<details>
+<summary>Do SSO users need to authenticate individually?</summary>
+
+Yes. Each SSO user must authenticate individually to connect their coding agent to the MCP server. 
+
+Authentication tokens are scoped per user session, so team members cannot share a single authenticated connection or bypass the login flow. When connecting for the first time, each team member will be prompted to complete the Chromatic SSO authentication flow in their browser.
+
+</details>

--- a/src/content/collaborate/mcp.mdx
+++ b/src/content/collaborate/mcp.mdx
@@ -252,7 +252,7 @@ To confirm the server itself is reachable before debugging your config, open the
 <details>
 <summary>Do SSO users need to authenticate individually?</summary>
 
-Yes. Each SSO user must authenticate individually to connect their coding agent to the MCP server. 
+Yes. Each SSO user must authenticate individually to connect their coding agent to the MCP server.
 
 Authentication tokens are scoped per user session, so team members cannot share a single authenticated connection or bypass the login flow. When connecting for the first time, each team member will be prompted to complete the Chromatic SSO authentication flow in their browser.
 

--- a/src/content/collaborate/mcp.mdx
+++ b/src/content/collaborate/mcp.mdx
@@ -180,3 +180,71 @@ export default config;
 ```
 
 </details>
+
+<details>
+<summary>I see "invalid_redirect_uri" or "redirect_uri not registered" when connecting</summary>
+
+There are two separate causes, and they need different fixes.
+
+**Your agent picked a random local port.** Some agents authenticate using a client metadata document as the client ID. Those agents choose an ephemeral loopback port at runtime — `http://localhost:52947/callback`, with a different port each time.
+
+Chromatic's authorization requires the redirect URI to match exactly. A port that changes between attempts won't match.
+
+**Your configuration uses the wrong key format.** Every agent expects the OAuth client ID under a different key, so copying a working config from one tool to another reliably fails. See the next entry.
+
+The most reliable fix for both is to let the `mcp-add` CLI write the configuration for you, rather than editing it by hand:
+
+```bash
+npx mcp-add --type http --url "https://<BRANCH>--<APP-ID>.chromatic.com/mcp" --client-id "cdf3737dff9d485485968e50b63fd8b4" --scope project
+```
+
+After changing any MCP configuration, start a new agent session — most agents only read it at startup.
+
+</details>
+
+<details>
+<summary>Where does the OAuth client ID go in my agent's config?</summary>
+
+Each agent expects a different key. Use the one for your tool:
+
+| Agent       | Expected key                  | Example                                         |
+| ----------- | ----------------------------- | ----------------------------------------------- |
+| Claude Code | `oauth.clientId` (camelCase)  | `{ "oauth": { "clientId": "your-client-id" } }` |
+| Cursor      | `auth.client_id` (snake_case) | `{ "auth": { "client_id": "your-client-id" } }` |
+| Codex       | `auth.CLIENT_ID` (uppercase)  | `{ "auth": { "CLIENT_ID": "your-client-id" } }` |
+
+Both the outer key (`oauth` vs `auth`) and the inner key's casing matter. A complete entry for Claude Code looks like this:
+
+```json title=".mcp.json"
+{
+  "mcpServers": {
+    "your-chromatic-storybook-mcp": {
+      "type": "http",
+      "url": "https://<BRANCH>--<APP-ID>.chromatic.com/mcp",
+      "oauth": {
+        "clientId": "cdf3737dff9d485485968e50b63fd8b4"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Which config file does my agent read?</summary>
+
+Editing the wrong file is a common cause of "my changes had no effect."
+
+| Agent           | Per-repository                    | Global                        |
+| --------------- | --------------------------------- | ----------------------------- |
+| Claude Code     | `.mcp.json`                       | `~/.claude.json`              |
+| Claude Desktop  | Not supported                     | `claude_desktop_config.json`  |
+| Cursor          | `.cursor/mcp.json`                | `~/.cursor/mcp.json`          |
+| Cline (VS Code) | `.vscode/cline_mcp_settings.json` | `cline_mcp_settings.json`     |
+| Continue        | `.continue/mcpServers/mcp.json`   | `~/.continue/config.json`     |
+| Zed             | Configured through settings UI    | `~/.config/zed/settings.json` |
+
+To confirm the server itself is reachable before debugging your config, open the MCP URL in a browser: `https://<BRANCH>--<APP-ID>.chromatic.com/mcp`.
+
+</details>

--- a/src/content/collaborate/mcp.mdx
+++ b/src/content/collaborate/mcp.mdx
@@ -26,7 +26,7 @@ However, unless you're running those Storybooks locally, your agents can't conne
 
 ## Setup guide
 
-To deploy your Storybook MCP server with Chromatic, you need to need to be using _Storybook 10.3 or later and use React_.
+To deploy your Storybook MCP server with Chromatic, you need to use Storybook 10.3 or later and React.
 
 ### 1. Install the MCP addon
 
@@ -42,7 +42,7 @@ When running Storybook's dev server, you can now access the MCP server at: http:
 
 ### 2. Run a build to publish the MCP server
 
-Run a Chromatic build as usual via CI or locally to automatically deploy your MCP server alongside your Storybook. If you don't have a Chromatic project yet then follow our [quickstart guide](/docs/quickstart) to set up your first project and publish the Storybook.
+Run a Chromatic build as usual, either via CI or locally, to automatically deploy your MCP server alongside your Storybook. If you don't have a Chromatic project yet, then follow our [quickstart guide](/docs/quickstart) to set up your first project and publish the Storybook.
 
 Once the build is complete, you will see a confirmation message with links to your published Storybook. The MCP server is published at the same URL as your Storybook on the `/mcp` route. For example:
 
@@ -52,7 +52,7 @@ https://642d765a7e8afcfb104268dc-mhlulncyca.chromatic.com/mcp
 
 ### 3. Enable composition
 
-If your UI pulls components from multiple Storybooks, you can compose them into a single MCP server. For example, your app might have a local Storybook while consuming a design system from a remote published Storybook.
+If your UI pulls components from multiple Storybooks, you can compose them into a single MCP server. For example, your app might have a local Storybook while consuming a design system from a published Storybook on a remote server.
 
 Use [composition](/docs/composition) to stitch together context from multiple Storybooks in your local MCP server. This allows agents to reference any component during UI generation.
 
@@ -64,7 +64,7 @@ Use [composition](/docs/composition) to stitch together context from multiple St
 To enable composition, add a `refs` section to your Storybook config. We recommend using your default branch's [permalink](/docs/permalinks) as the ref URL. For example:
 
 ```js title="storybook/main.ts"
-// Replace your-framework with the framework you are using, e.g. react-vite, nextjs, vue3-vite, etc.
+// Replace your-framework with the framework you are using, e.g., react-vite, nextjs, vue3-vite, etc.
 import type { StorybookConfig } from "@storybook/your-framework";
 
 const config: StorybookConfig = {
@@ -86,9 +86,9 @@ export default config;
 
 ![In your Storybook you should see the composed components in the sidebar](../../images/reference-external-storybooks-composition.png)
 
-### 4. Install MCP server in your coding agent
+### 4. Install the MCP server in your coding agent
 
-Run the following command to configure the local MCP server for your coding agent. We only need to connect local MCP server because the remote Storybook is composed into the local Storybook.
+Run the following command to configure the local MCP server for your coding agent. We only need to connect to the local MCP server because the remote Storybook is composed into the local Storybook.
 
 ```bash
 npx mcp-add --type http --url "https://localhost:6006/mcp" --client-id "cdf3737dff9d485485968e50b63fd8b4" --scope project
@@ -104,7 +104,7 @@ npx mcp-add --type http --url "https://localhost:6006/mcp" --client-id "cdf3737d
 
 For private Storybooks, your coding agent must authenticate with Chromatic to access the MCP server. Chromatic uses [CIMD](https://client.dev/) to authenticate with tools that support it, such as VSCode and Copilot. For other coding agents, like Claude Code and Cursor, it uses a static client ID: `cdf3737dff9d485485968e50b63fd8b4`.
 
-The `mcp-add` command above was already configured with the required client ID for authentication. The first time your agent connects to the MCP server you'll be prompted to sign in with Chromatic. Follow the instructions in the authentication flow to grant access.
+The `mcp-add` command above was already configured with the required client ID for authentication. The first time your agent connects to the MCP server, you'll be prompted to sign in with Chromatic. Follow the instructions in the authentication flow to grant access.
 
 ![Authentication screen in Chromatic asking for permission to connect to VS Code](../../images/mcp-auth.png)
 


### PR DESCRIPTION
Adds three FAQ entries to the MCP page covering the authentication failures support has been fielding.

- **`invalid_redirect_uri` / `redirect_uri not registered`** — two distinct causes (ephemeral loopback port from CIMD-style auth, and a wrong client ID key), with the `mcp-add` command as the fix for both.
- **Where the OAuth client ID goes** — Claude Code, Cursor, and Codex each expect a different key and casing, so copying a working config between tools fails. Includes a complete `.mcp.json` entry.
- **Which config file each agent reads** — per-repo vs. global paths for Claude Code, Claude Desktop, Cursor, Cline, Continue, and Zed.

Content-only change to `src/content/collaborate/mcp.mdx`. Build passes, unit tests pass, Prettier clean.

Closes SUP-495: https://linear.app/chromaui/issue/SUP-495/collaboratemcpmdx-add-mcp-authentication-troubleshooting
