### PR TITLE
docs(turbosnap): document repo-root vs cwd path options

### DIFF
--- a/src/content/ci/github-actions.mdx
+++ b/src/content/ci/github-actions.mdx
@@ -371,7 +371,7 @@ jobs:
 
 <div class="aside">
 
-TurboSnap is highly customizable and can be configured to fit your requirements. For more information, read our [documentation](/docs/turbosnap).
+TurboSnap is highly customizable and can be configured to fit your requirements. For more information, read our [documentation](/docs/turbosnap). If you're combining `onlyChanged` with `workingDir`, check [TurboSnap config paths](/docs/turbosnap/config-paths) — `workingDir` changes the base for some path options but not others.
 
 </div>
 

--- a/src/content/configuration/monorepos.md
+++ b/src/content/configuration/monorepos.md
@@ -124,7 +124,7 @@ TurboSnap is an excellent feature to use with monorepos to avoid re-snapshotting
 
 The `--untraced` CLI flag can be used to ignore all changes outside of a package or related packages. For example, given a monorepo with unrelated packages `UI` and `app`, you can add the following CLI option to `UI`’s Chromatic command to only run snapshots when files inside the `UI` package change: `--untraced \"./packages/!(UI)/**\"` .
 
-Note that the glob pattern starts from the root directory of the repository, not from the directory of the `UI` package. You can also specify `--untraced` multiple times to include multiple glob patterns.
+Note that the glob pattern starts from the root directory of the repository, not from the directory of the `UI` package. You can also specify `--untraced` multiple times to include multiple glob patterns. Setting `--working-dir` does not change that, and other path options resolve differently — see [TurboSnap config paths](/docs/turbosnap/config-paths).
 
 ```shell
 npx chromatic --only-changed --untraced=package.json,yarn.lock --exit-zero-on-changes

--- a/src/content/turbosnap/config-paths.mdx
+++ b/src/content/turbosnap/config-paths.mdx
@@ -58,7 +58,7 @@ Given a Storybook in `client/`, with these directories:
 📂 Storybook Config Directory: ./client/.storybook
 ```
 
-a working GitHub Actions step looks like this:
+A working GitHub Actions step looks like this:
 
 ```yaml
 - name: Build Storybook

--- a/src/content/turbosnap/config-paths.mdx
+++ b/src/content/turbosnap/config-paths.mdx
@@ -1,0 +1,140 @@
+---
+title: TurboSnap config paths
+description: TurboSnap's path options resolve against different bases. Learn which options are relative to your repository root and which are relative to your working directory.
+sidebar: { order: 8, label: 'Config paths' }
+slug: 'turbosnap/config-paths'
+---
+
+# TurboSnap config paths
+
+TurboSnap's path options don't all resolve against the same base. Some are relative to your repository root, others to the current working directory. Mixing them up is the most common reason TurboSnap looks for your Storybook in the wrong place — especially in a monorepo, where `workingDir` moves the goalposts for some options but not others.
+
+For what each option does, see the [configuration options reference](/docs/configure#options). For setting TurboSnap up in the first place, see [Setup](/docs/turbosnap/setup).
+
+## Which base each option uses
+
+**Relative to the repository root:**
+
+- `untraced`
+- `externals`
+- `storybookBaseDir`
+
+**Relative to the current working directory:**
+
+- `storybookConfigDir`
+- `storybookBuildDir`
+
+`workingDir` changes the current working directory, so it affects the second group and leaves the first group alone.
+
+<div class="aside">
+
+ℹ️ `storybookBaseDir` defaults to the current working directory expressed relative to the repository root. If you set it explicitly, your value is read as repo-root-relative — not as an addition to `workingDir`.
+
+</div>
+
+## Why `storybookBaseDir` exists
+
+`storybookBaseDir` corrects a mismatch between two sets of file paths:
+
+- the paths inside `preview-stats.json`, which your Storybook build generates
+- the paths returned by `git diff --name-only`, which TurboSnap runs
+
+If your Storybook build and the `chromatic` command run from the same working directory, the two line up and you don't need `storybookBaseDir` at all. If they run from different directories, the paths won't match and TurboSnap can't connect a changed file to the stories that depend on it.
+
+One exception: if your `build-storybook` script changes directory before invoking `storybook build`, the paths can diverge even when Chromatic builds your Storybook for you.
+
+<div class="aside">
+
+✨ Run `npx @chromatic-com/turbosnap-helper` from your repository root and it will report the correct base and config directories for your project, and can update your config file for you.
+
+</div>
+
+## Worked example
+
+Given a Storybook in `client/`, with these directories:
+
+```bash
+📙 Storybook Base Directory: ./client
+📂 Storybook Config Directory: ./client/.storybook
+```
+
+a working GitHub Actions step looks like this:
+
+```yaml
+- name: Build Storybook
+  run: npm run build-storybook -- -o ./client/storybook-static -c ./client/.storybook
+- name: Publish to Chromatic
+  uses: chromaui/action@latest
+  with:
+    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+    workingDir: client
+    onlyChanged: true
+    # 👇 relative to workingDir, so no ./client prefix
+    storybookBuildDir: storybook-static
+    externals: |
+      ./client/public/*.css
+      **/*.sass
+    untraced: |
+      **/preview.js
+      # 👇 relative to the repository root, so ./client is required
+      ./client/src/utils.tsx
+```
+
+Notes on each option in that config:
+
+- `storybookBuildDir` is cwd-relative, and `workingDir` has already moved the cwd to `client`, so it's `storybook-static` rather than `./client/storybook-static`.
+- `storybookConfigDir` is omitted entirely. It defaults to `.storybook`, which is correct once the cwd is `client`.
+- `storybookBaseDir` is omitted. Its default is the cwd relative to the repository root, which is `./client` — already right.
+- `untraced` and `externals` are repo-root-relative and are unaffected by `workingDir`, so they need the `./client` prefix. A pattern like `./src/utils.tsx` would silently match nothing.
+
+For more on monorepo setups, see [Using TurboSnap in a monorepo](/docs/turbosnap/setup#using-turbosnap-in-a-monorepo) and [Optimizing TurboSnap for monorepos](/docs/turbosnap/monorepo-usage).
+
+## Common failures
+
+<details>
+<summary>The config directory path is duplicated (<code>foo/bar/foo/bar/.storybook</code>)</summary>
+
+You've set `storybookConfigDir` to a repo-root-relative path while also using `workingDir`. Because `storybookConfigDir` is cwd-relative, Chromatic appends your value to the working directory.
+
+```yaml
+# ✖ Chromatic looks for web/app/web/app/sb-config/.storybook
+workingDir: web/app
+storybookConfigDir: web/app/sb-config/.storybook
+
+# ✔ relative to the working directory
+workingDir: web/app
+storybookConfigDir: sb-config/.storybook
+```
+
+If your config directory is at the default location inside your working directory, drop `storybookConfigDir` altogether.
+
+</details>
+
+<details>
+<summary>The base directory resolves to the repository root instead of a subdirectory</summary>
+
+You've set `workingDir` in CI but `storybookBaseDir` somewhere else — in your `chromatic` script or `chromatic.config.json` — with a path relative to the subproject rather than the repository.
+
+```json title="chromatic.config.json"
+// ✖ Chromatic looks for ./app/sb at the repository root
+{ "storybookBaseDir": "./app/sb" }
+```
+
+Because `storybookBaseDir` is repo-root-relative, `workingDir: web/services` does not make this resolve to `./web/services/app/sb`. Either give the full repo-root-relative path, or set it in the Chromatic step of your CI workflow where the full path is natural:
+
+```yaml
+storybookBaseDir: web/services/app/sb
+```
+
+Flags take precedence over config-file options, and you can supply both in the same build. Check every place a path might be set: your CI configuration, your `package.json` scripts, and `chromatic.config.json`.
+
+</details>
+
+<details>
+<summary>I see "No manifest or lockfile found at the root of the repository"</summary>
+
+TurboSnap is looking for your project's manifest and lockfile in the wrong place, which usually means your Storybook configuration lives in a subdirectory and the base directory isn't set correctly.
+
+Run `npx @chromatic-com/turbosnap-helper` from your repository root to get the correct value. If you still can't determine the right path, generate a trimmed stats file and use the [`trace` utility](/docs/turbosnap/trace-utility) to see which paths TurboSnap resolves.
+
+</details>

--- a/src/content/turbosnap/setup-turbosnap.mdx
+++ b/src/content/turbosnap/setup-turbosnap.mdx
@@ -384,6 +384,12 @@ If you're using a prebuilt Storybook as opposed to having Chromatic build your S
 
 This would ensure we're checking `packages/webapp` for your Storybook project instead of your root directory, which may end up detecting unexpected package control files for other subprojects. Even though the default config directory is being used, you'll want to ensure to set `--storybook-config-dir` as well since this path is relative to your current working directory.
 
+<div class="aside">
+
+ℹ️ These options don't share a base directory: some resolve against your repository root, others against your current working directory. See [TurboSnap config paths](/docs/turbosnap/config-paths) for the full breakdown and a worked monorepo example.
+
+</div>
+
 If you're using the `--externals` or `--untraced` flags in a monorepo, you'll want to be mindful that the paths specified are relative to your repository root. For example, let's say you want to ignore some global decorators in your `packages/webapp` project:
 
 ```shell

--- a/src/content/turbosnap/troubleshooting-turbosnap.mdx
+++ b/src/content/turbosnap/troubleshooting-turbosnap.mdx
@@ -21,6 +21,8 @@ If the build output shows no story files being detected by changes, there might 
 
 Another reason that changes may be missed is if the changed files aren't directly included in the webpack build; use the [`externals` flag](/docs/turbosnap/setup#specify-external-files-to-trigger-a-full-re-test-when-they-change) to tell Chromatic about this.
 
+Path resolution is the other common cause, especially in a monorepo. `untraced` and `externals` patterns are relative to your repository root, while `storybookConfigDir` and `storybookBuildDir` are relative to your working directory, so a pattern with the wrong prefix silently matches nothing. See [TurboSnap config paths](/docs/turbosnap/config-paths).
+
 ## Why are changes not being detected correctly?
 
 Teams frequently use an index file ([barrel file](https://basarat.gitbook.io/typescript/main-1/barrel)) to simplify imports. This practice allows for easier importing, such as accessing a component from `@component-library` instead of specifying the full path like `@component-library/elements/table`. However, the usage of barrels impacts TurboSnap's ability to detect changes.

--- a/src/content/turbosnap/turbosnap-best-practices.md
+++ b/src/content/turbosnap/turbosnap-best-practices.md
@@ -55,6 +55,8 @@ If your Storybook config or preview files don't live in the default `./.storyboo
 - `storybookBaseDir` sets the root for dependency tracing (what source files are considered part of the Storybook project)
 - `storybookConfigDir` tells Chromatic where to find your Storybook configuration (the path where your `main.js|ts` and `preview.js|ts` live)
 
+These two options resolve against different bases. See [TurboSnap config paths](/docs/turbosnap/config-paths) for which options are relative to your repository root and which are relative to your working directory.
+
 If your directories are not properly configured, changes to unrelated files—like your root `package.json` or backend utilities—can trigger full rebuilds.
 
 <div class="aside">

--- a/src/content/turbosnap/turbosnap-for-monorepos.md
+++ b/src/content/turbosnap/turbosnap-for-monorepos.md
@@ -1,7 +1,7 @@
 ---
 title: Optimizing TurboSnap for monorepos
 description: Tips to optimize your TurboSnap configuration when working with a monorepo
-sidebar: { order: 8, label: 'Monorepo usage' }
+sidebar: { order: 9, label: 'Monorepo usage' }
 slug: 'turbosnap/monorepo-usage'
 ---
 
@@ -10,6 +10,8 @@ slug: 'turbosnap/monorepo-usage'
 For large teams using a monorepo and managing changes across dozens of packages, it's crucial not just to run tests faster but to run the right ones. TurboSnap excels in these scenarios by accelerating test runs, executing UI tests only on what has actually changed. However, poorly structured dependencies can derail your whole setup. Constantly triggering full rebuilds or skipping coverage on affected components makes it impossible to trust the results.
 
 In this guide, we’ll break down practical strategies for managing `dependencies`, `devDependencies`, dynamic imports, and `package.json` files in a way that keeps your TurboSnap builds snappy _and_ your coverage meaningful.
+
+Before tuning dependencies, confirm your directory options point where you expect. In a monorepo, some path options are relative to your repository root and others to your working directory — [TurboSnap config paths](/docs/turbosnap/config-paths) covers which is which.
 
 <div class="aside">
 


### PR DESCRIPTION
New page documenting which TurboSnap path options resolve against the repository root (`untraced`, `externals`, `storybookBaseDir`) and which resolve against the current working directory (`storybookConfigDir`, `storybookBuildDir`), plus what `workingDir` does and does not change.

This is the most common TurboSnap misconfiguration in support threads, and the answer was previously spread across the setup and monorepo pages.

## What's here

- `src/content/turbosnap/config-paths.mdx` — the new page: which base each option uses, why `storybookBaseDir` exists, a worked GitHub Actions example with per-option notes, and three common failures as collapsible sections.
- Cross-links from the pages where the question comes up: TurboSnap setup (monorepo section), troubleshooting ("why are no changes being detected?"), best practices, monorepo usage, the monorepos guide (`#with-turbosnap`), and the GitHub Actions guide (`onlyChanged` + `workingDir`).

## Verification

`node scripts/verify-internal-links.mjs --changed` — 7 files, 0 broken links, 0 informational. Every internal link and anchor resolves against a real local build.

Closes SUP-496 (https://linear.app/chromaui/issue/SUP-496)
