### PR TITLE
Note that Teams must be enabled by support

### DIFF
--- a/src/content/access/teams.mdx
+++ b/src/content/access/teams.mdx
@@ -9,6 +9,12 @@ sidebar: { order: 4, label: 'Teams' }
 
 Teams are available to organizations on the [Enterprise plan](/pricing). They let you control which users can access which projects in your Chromatic organization. Instead of assigning individuals to projects one by one, you assign groups synced from your identity provider (e.g., "Engineering" or "QA") to projects, while membership is managed centrally in your identity provider.
 
+<div class="aside">
+
+ℹ️ Teams are not enabled by default. To turn them on for your organization, contact us via in-app chat or email [support@chromatic.com](mailto:support@chromatic.com?Subject=Enable%20Teams).
+
+</div>
+
 ## How it works
 
 An **organization** is the top-level container in Chromatic that holds:
@@ -19,7 +25,7 @@ An **organization** is the top-level container in Chromatic that holds:
 
 ## Setting up teams
 
-Teams require [SSO with directory sync (SCIM)](/docs/access/sso). Each team in Chromatic corresponds to a directory group in your identity provider (IdP), such as Okta. Teams are provisioned automatically from the directory groups your IdP pushes via SCIM; they cannot be created or edited manually in Chromatic.
+Teams must be enabled for your organization by Chromatic support, and they require [SSO with directory sync (SCIM)](/docs/access/sso). Each team in Chromatic corresponds to a directory group in your identity provider (IdP), such as Okta. Teams are provisioned automatically from the directory groups your IdP pushes via SCIM; they cannot be created or edited manually in Chromatic.
 
 When a directory group is synced via SCIM:
 


### PR DESCRIPTION
Teams aren't turned on by default for an organization, but the docs read as though an Enterprise customer with SCIM can just start using them. This adds that missing step.

### Changes

`src/content/access/teams.mdx`:

- Added a callout under the intro noting Teams are not enabled by default, pointing users to in-app chat or [support@chromatic.com](mailto:support@chromatic.com) to have it turned on.
- Added the same requirement to the **Setting up teams** prerequisites, alongside the existing SSO/SCIM requirement, so it's visible to anyone skimming straight to the setup steps.

### Verification

- `prettier --check` passes (also via the pre-commit hook).
- Internal link check against a local build: `Checked 1 file(s): 0 broken link(s), 1 informational` — the informational item is the pre-existing off-site `/pricing` link.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUhEaZ9dKyHiw4zop1daRh)_